### PR TITLE
Remove Avg. MMR and players' MMR from match page #1352

### DIFF
--- a/src/components/Distributions/index.jsx
+++ b/src/components/Distributions/index.jsx
@@ -10,6 +10,7 @@ import {
   sum,
   abbreviateNumber,
   getOrdinal,
+  rankTierToString,
 } from 'utility';
 // import Warning from 'components/Alerts';
 import TabBar from 'components/TabBar';
@@ -95,7 +96,7 @@ const getPage = (data, key) => {
   let rows = data && data[key] && data[key].rows;
   if (key === 'ranks') {
     // Translate the rank integers into names
-    rows = rows.map(r => ({ ...r, bin_name: `${strings[`rank_tier_${Math.floor(r.bin_name / 10)}`]} ${r.bin_name % 10}` }));
+    rows = rows.map(r => ({ ...r, bin_name: rankTierToString(r.bin_name) }));
   }
   return (
     <div>

--- a/src/components/Match/MatchHeader/MatchHeader.jsx
+++ b/src/components/Match/MatchHeader/MatchHeader.jsx
@@ -229,8 +229,6 @@ const MatchHeader = ({ match, user, loading }) => {
       player =>
         ((radiant === undefined || radiant === isRadiant(player.player_slot)) ? Number(player[key]) : null);
 
-    const mmrPlayers = match.players.map(mapPlayers('solo_competitive_rank')).filter(Boolean);
-
     const victorySection = match.radiant_win
       ? (
         <span>
@@ -299,10 +297,6 @@ const MatchHeader = ({ match, user, loading }) => {
               <li>
                 <span>{strings.th_skill}</span>
                 {(match.skill) ? strings[`skill_${match.skill}`] : strings.general_unknown}
-              </li>
-              <li>
-                <span>{strings.match_avg_mmr}</span>
-                {(mmrPlayers.length) ? (mmrPlayers.reduce(sum, 0) / mmrPlayers.length).toFixed(0) : strings.general_unknown}
               </li>
             </ul>
           </div>

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -9,7 +9,7 @@ import abilityKeys from 'dotaconstants/build/ability_keys.json';
 import buffs from 'dotaconstants/build/permanent_buffs.json';
 import util from 'util';
 import strings from 'lang';
-import { formatSeconds, abbreviateNumber, transformations, percentile, sum, subTextStyle, getHeroesById } from 'utility';
+import { formatSeconds, abbreviateNumber, transformations, percentile, sum, subTextStyle, getHeroesById, rankTierToString } from 'utility';
 import { TableHeroImage, inflictorWithValue } from 'components/Visualizations';
 import ReactTooltip from 'react-tooltip';
 import { RadioButton } from 'material-ui/RadioButton';
@@ -28,7 +28,7 @@ export const heroTd = (row, col, field, index, hideName, party, showPvgnaGuide =
     registered={row.last_login}
     accountId={row.account_id}
     playerSlot={row.player_slot}
-    subtitle={<CompetitiveRank rankTier={row.rank_tier} />}
+    subtitle={<CompetitiveRank rankTier={rankTierToString(row.rank_tier)} />}
     hideText={hideName}
     confirmed={row.account_id && row.name}
     party={party}

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -14,6 +14,7 @@ import { TableHeroImage, inflictorWithValue } from 'components/Visualizations';
 import ReactTooltip from 'react-tooltip';
 import { RadioButton } from 'material-ui/RadioButton';
 import ActionOpenInNew from 'material-ui/svg-icons/action/open-in-new';
+import { CompetitiveRank } from 'components/Visualizations/Table/HeroImage';
 import { IconBackpack, IconRadiant, IconDire } from 'components/Icons';
 import constants from '../constants';
 import { StyledAbilityUpgrades, StyledBackpack, StyledCosmetic, StyledDivClearBoth, StyledGoldIcon, StyledPlayersDeath, StyledRunes, StyledUnusedItem } from './StyledMatch';
@@ -27,6 +28,7 @@ export const heroTd = (row, col, field, index, hideName, party, showPvgnaGuide =
     registered={row.last_login}
     accountId={row.account_id}
     playerSlot={row.player_slot}
+    subtitle={<CompetitiveRank rankTier={row.rank_tier} />}
     hideText={hideName}
     confirmed={row.account_id && row.name}
     party={party}

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -27,7 +27,7 @@ export const heroTd = (row, col, field, index, hideName, party, showPvgnaGuide =
     title={row.name || row.personaname || strings.general_anonymous}
     registered={row.last_login}
     accountId={row.account_id}
-    subtitle={<Mmr number={row.solo_competitive_rank} />}
+    /*subtitle={<Mmr number={row.competitive_rank} />}*/
     playerSlot={row.player_slot}
     hideText={hideName}
     confirmed={row.account_id && row.name}

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -14,7 +14,6 @@ import { TableHeroImage, inflictorWithValue } from 'components/Visualizations';
 import ReactTooltip from 'react-tooltip';
 import { RadioButton } from 'material-ui/RadioButton';
 import ActionOpenInNew from 'material-ui/svg-icons/action/open-in-new';
-import { Mmr } from 'components/Visualizations/Table/HeroImage';
 import { IconBackpack, IconRadiant, IconDire } from 'components/Icons';
 import constants from '../constants';
 import { StyledAbilityUpgrades, StyledBackpack, StyledCosmetic, StyledDivClearBoth, StyledGoldIcon, StyledPlayersDeath, StyledRunes, StyledUnusedItem } from './StyledMatch';
@@ -27,7 +26,6 @@ export const heroTd = (row, col, field, index, hideName, party, showPvgnaGuide =
     title={row.name || row.personaname || strings.general_anonymous}
     registered={row.last_login}
     accountId={row.account_id}
-    /*subtitle={<Mmr number={row.competitive_rank} />}*/
     playerSlot={row.player_slot}
     hideText={hideName}
     confirmed={row.account_id && row.name}

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -402,4 +402,27 @@ Mmr.propTypes = {
   number: PropTypes.number,
 };
 
+export const CompetitiveRank = ({ rankTier }) => (
+  <span>
+    <section
+      data-hint="Competitive rank"
+      data-hint-position="bottom"
+    >
+      <SocialPerson />
+    </section>
+    {rankTier && rankTier === parseInt(rankTier, 10) ?
+      <span>
+        {strings[`rank_tier_${parseInt(rankTier / 10, 10)}`]} { (parseInt(rankTier, 10) > 9) && <span>[{parseInt(rankTier % 10, 10)}]</span> }
+      </span>
+      :
+      <span>
+        { strings.general_unknown }
+      </span>
+    }
+  </span>
+);
+CompetitiveRank.propTypes = {
+  rankTier: PropTypes.number,
+};
+
 export default TableHeroImage;

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -405,20 +405,12 @@ Mmr.propTypes = {
 export const CompetitiveRank = ({ rankTier }) => (
   <span>
     <section
-      data-hint="Competitive rank"
+      data-hint={strings.th_rank}
       data-hint-position="bottom"
     >
       <SocialPerson />
     </section>
-    {rankTier && rankTier === parseInt(rankTier, 10) ?
-      <span>
-        {strings[`rank_tier_${parseInt(rankTier / 10, 10)}`]} { (parseInt(rankTier, 10) > 9) && <span>[{parseInt(rankTier % 10, 10)}]</span> }
-      </span>
-      :
-      <span>
-        { strings.general_unknown }
-      </span>
-    }
+    {rankTier}
   </span>
 );
 CompetitiveRank.propTypes = {

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -59,6 +59,18 @@ export function abbreviateNumber(num) {
   return num.toFixed(0);
 }
 
+export function rankTierToString(rankTier) {
+  if (rankTier !== parseInt(rankTier, 10)) {
+    return strings.general_unknown;
+  }
+  const intRankTier = parseInt(rankTier, 10);
+  let rank = strings[`rank_tier_${parseInt(intRankTier / 10, 10)}`];
+  if (intRankTier > 9) {
+    rank += ` [${parseInt(intRankTier % 10, 10)}]`;
+  }
+  return rank;
+}
+
 export function formatSeconds(input) {
   if (!Number.isNaN(parseFloat(input)) && Number.isFinite(Number(input))) {
     const absTime = Math.abs(input);


### PR DESCRIPTION
#1352 Removed the average match MMR and individual players' MMR from match page.

Removing the MMR leaves the subtitle empty, or ugly (when there are the `randomed` or `predicted` flags), so I replaced it with the competitive rank name. But as the rank is not returned in the /matches API for now, it will show as Unknown.

