### PR TITLE
party indicators are bugged in current implemantation

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -63,7 +63,6 @@ function findParties(partyArray) {
 
 const partyStyles = (row, match) => {
   if (match.players && match.players.map(player => player.party_id).reduce(sum) > 0 && row.party_size > 1) {
-    console.log(match.players.map(player => player.party_id))
     const parties = findParties(match.players.map(player => player.party_id));
     const findGroup = parties.indexOf(row.party_id);
     return <div className={`group${findGroup}`} />;

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -62,7 +62,8 @@ function findParties(partyArray) {
 }
 
 const partyStyles = (row, match) => {
-  if (match.players && row.party_size > 1) {
+  if (match.players && match.players.map(player => player.party_id).reduce(sum) > 0 && row.party_size > 1) {
+    console.log(match.players.map(player => player.party_id))
     const parties = findParties(match.players.map(player => player.party_id));
     const findGroup = parties.indexOf(row.party_id);
     return <div className={`group${findGroup}`} />;

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -49,9 +49,23 @@ export const heroTdColumn = {
   sortFn: true,
 };
 
+function findParties(partyArray) {
+  const parties = [];
+  partyArray.forEach((element, index) => {
+    if (partyArray.indexOf(element, index + 1) > -1) {
+      if (parties.indexOf(element) === -1) {
+        parties.push(element);
+      }
+    }
+  });
+  return parties;
+}
+
 const partyStyles = (row, match) => {
-  if (match.players && match.players.filter(x => x.party_size > 1).length) {
-    return <div className={`group${row.party_id}`} />;
+  if (match.players && row.party_size > 1) {
+    const parties = findParties(match.players.map(player => player.party_id));
+    const findGroup = parties.indexOf(row.party_id);
+    return <div className={`group${findGroup}`} />;
   }
   return null;
 };


### PR DESCRIPTION
when the array with party IDs looks like this for example it does not work properly. 

https://stage.opendota.com/matches/3575778268/
[0, 1, 2, **3, 3**, 4, 5, 6, 7, 8]  (party ID array)

player 0, 1 and 2 get each treated like an individual party. then the two players with ID 3. 
players  5,6,7,8,9   get treated like a **single** party.

another example:
https://stage.opendota.com/matches/3595762027
party_id array [0, 0, 1, 1, 2, 3, 4, 5, 5, 5]

should be:
party_0: player 0 & 1
party_1: player 2 & 3
party_2: player 7 & 8 & 9

more bugged examples: 
https://stage.opendota.com/matches/3593083952/


also team matches with arrays like  this [0,0,0,0,0,0,0,0,0,0]:
https://stage.opendota.com/matches/3597234172

I tried to patch this issue without changing the original implementation too much.