### PR TITLE
cap ward lifespans and exclude some wards from average 

### DIFF
--- a/src/components/Match/Vision/VisionLog.jsx
+++ b/src/components/Match/Vision/VisionLog.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import items from 'dotaconstants/build/items.json';
 import { threshold, formatSeconds } from 'utility';
 import Table from 'components/Table';
 import strings from 'lang';
@@ -76,7 +77,10 @@ function logWard(log) {
 
 const generateData = match => (log) => {
   const wardKiller = (log.left && log.left.player1) ? heroTd(match.players[log.left.player1]) : '';
-  const duration = log.left ? log.left.time - log.entered.time : '';
+  const duration = (log.left && log.left.time - log.entered.time) || (match && match.duration - log.entered.time)
+
+  // necessary until https://github.com/odota/parser/pull/3 is implemented
+  const discrepancy = duration - Math.min(items['ward_'+log.type].attrib.find(x => x.key === 'lifetime').value, duration)
 
   const durationColor = log.type === 'observer' ? durationObserverColor(duration) : durationSentryColor(duration);
 
@@ -84,8 +88,8 @@ const generateData = match => (log) => {
     ...match.players[log.player],
     type: <img height="29" src={`${process.env.REACT_APP_API_HOST}/apps/dota2/images/items/ward_${log.type}_lg.png`} alt="" />,
     enter_time: formatSeconds(log.entered.time),
-    left_time: formatSeconds(log.left && log.left.time) || '-',
-    duration: <span style={{ color: durationColor }}>{formatSeconds(duration)}</span>,
+    left_time: formatSeconds(((log.left && log.left.time) || (match && match.duration)) - discrepancy) || '-',
+    duration: <span style={{ color: durationColor }}>{formatSeconds(duration - discrepancy)}</span>,
     killer: wardKiller,
     placement: logWard(log),
   };

--- a/src/components/Match/Vision/VisionLog.jsx
+++ b/src/components/Match/Vision/VisionLog.jsx
@@ -77,10 +77,10 @@ function logWard(log) {
 
 const generateData = match => (log) => {
   const wardKiller = (log.left && log.left.player1) ? heroTd(match.players[log.left.player1]) : '';
-  const duration = (log.left && log.left.time - log.entered.time) || (match && match.duration - log.entered.time)
+  const duration = (log.left && log.left.time - log.entered.time) || (match && match.duration - log.entered.time);
 
   // necessary until https://github.com/odota/parser/pull/3 is implemented
-  const discrepancy = duration - Math.min(items['ward_'+log.type].attrib.find(x => x.key === 'lifetime').value, duration)
+  const discrepancy = duration - Math.min(items[`ward_${log.type}`].attrib.find(x => x.key === 'lifetime').value, duration);
 
   const durationColor = log.type === 'observer' ? durationObserverColor(duration) : durationSentryColor(duration);
 

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -1058,9 +1058,11 @@ const computeAverage = (row, type) => {
   const totalDuration = [];
   row[`${type}_log`].forEach((ward) => {
     const findTime = row[`${type}_left_log`].find(x => x.ehandle === ward.ehandle);
-    const leftTime = (findTime && findTime.time) || row.duration;
-    const duration = Math.min(Math.max(leftTime - ward.time, 0), maxDuration);
-    totalDuration.push(duration);
+    const leftTime = (findTime && findTime.time) || false;
+    if (leftTime !== false) { // exclude wards that did not expire before game ended from average time
+      const duration = Math.min(Math.max(leftTime - ward.time, 0), maxDuration);
+      totalDuration.push(duration);
+    }
   });
   let sum = 0;
   for (let i = 0; i < totalDuration.length; i += 1) {


### PR DESCRIPTION
-Cap the maximal duration for wards. Necessary until https://github.com/odota/parser/pull/3 is implemented.

-If a ward does not expire before game ends, then set it's left time equal to the game duration

-Exclude wards that did not expire before the game ended when calculating the average lifespan in order to not distort the average time.