### PR TITLE
Function to underline "best" values in Tables

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -98,6 +98,7 @@ export const overviewColumns = (match) => {
       sortFn: true,
       maxFn: true,
       sumFn: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_kills,
@@ -106,6 +107,7 @@ export const overviewColumns = (match) => {
       sortFn: true,
       displayFn: transformations.kda,
       sumFn: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_deaths,
@@ -113,6 +115,7 @@ export const overviewColumns = (match) => {
       field: 'deaths',
       sortFn: true,
       sumFn: true,
+      underline: 'min',
     },
     {
       displayName: strings.th_assists,
@@ -120,6 +123,7 @@ export const overviewColumns = (match) => {
       field: 'assists',
       sortFn: true,
       sumFn: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_gold_per_min,
@@ -129,6 +133,7 @@ export const overviewColumns = (match) => {
       color: constants.golden,
       sumFn: true,
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_xp_per_min,
@@ -137,6 +142,7 @@ export const overviewColumns = (match) => {
       sortFn: true,
       sumFn: true,
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_last_hits,
@@ -145,6 +151,7 @@ export const overviewColumns = (match) => {
       sortFn: true,
       sumFn: true,
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_denies,
@@ -153,6 +160,7 @@ export const overviewColumns = (match) => {
       sortFn: true,
       sumFn: true,
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_hero_damage,
@@ -162,6 +170,7 @@ export const overviewColumns = (match) => {
       sumFn: true,
       displayFn: row => abbreviateNumber(row.hero_damage),
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_hero_healing,
@@ -171,6 +180,7 @@ export const overviewColumns = (match) => {
       sumFn: true,
       displayFn: row => abbreviateNumber(row.hero_healing),
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_tower_damage,
@@ -180,6 +190,7 @@ export const overviewColumns = (match) => {
       sortFn: true,
       sumFn: true,
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: (
@@ -195,6 +206,7 @@ export const overviewColumns = (match) => {
       sumFn: true,
       displayFn: row => abbreviateNumber(row.total_gold),
       // relativeBars: true,
+      underline: 'max',
     },
     {
       displayName: strings.th_items,

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -41,6 +41,18 @@ const getColumnMin = (data, field, getValue) => {
   return Math.min(...valuesArr);
 };
 
+const toUnderline = (data, row, field, underline) => {
+  const x = [];
+  data.forEach((r) => {
+    x.push([r.player_slot, r[field]]);
+  });
+  x.sort((a, b) => a[1] - b[1]);
+  if ((underline === 'min' && x[0][0] === row.player_slot) || ((underline === 'max' && x[x.length - 1][0] === row.player_slot))) {
+    return true;
+  }
+  return false;
+};
+
 const initialState = {
   currentPage: 0,
   sortState: '',
@@ -164,13 +176,16 @@ class Table extends React.Component {
                     {columns.map((column, colIndex) => {
                       const {
                         field, color, center, displayFn, relativeBars, percentBars,
-                        percentBarsWithValue, sortFn, invertBarColor,
+                        percentBarsWithValue, sortFn, invertBarColor, underline,
                       } = column;
                       const getValue = typeof sortFn === 'function' ? sortFn : null;
                       const value = getValue ? getValue(row) : row[field];
                       const style = {
                         overflow: `${field === 'kills' ? 'visible' : null}`,
                         color,
+                        marginBottom: 0,
+                        textUnderlinePosition: 'under',
+                        textDecorationColor: 'rgb(140, 140, 140)',
                       };
 
                       if (center) {
@@ -229,6 +244,9 @@ class Table extends React.Component {
                         fieldEl = displayFn(row, column, value, index);
                       } else {
                         fieldEl = value;
+                      }
+                      if (underline === 'max' || underline === 'min') {
+                        style.textDecoration = toUnderline(data, row, field, underline) ? 'underline' : 'none';
                       }
                       return (
                         <MaterialTableRowColumn key={`${index}_${colIndex}`} style={style}>

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -48,6 +48,12 @@ const toUnderline = (data, row, field, underline) => {
   });
   x.sort((a, b) => a[1] - b[1]);
   if ((underline === 'min' && x[0][0] === row.player_slot) || ((underline === 'max' && x[x.length - 1][0] === row.player_slot))) {
+    if (underline === 'min' && x[0][1] === x[1][1]) {
+      return false;
+    }
+    if (underline === 'max' && x[x.length - 2][1] === x[x.length - 1][1]) {
+      return false;
+    }
     return true;
   }
   return false;


### PR DESCRIPTION
fixes https://github.com/odota/web/issues/1394

I copied dotabuff's behavior that if two or more players have the best value then no value gets underlined.

I only enabled in the Overview table for now.