### PR TITLE
added listStyle to prevent dropdown in forms from overflowing

### DIFF
--- a/src/components/Form/FormField.jsx
+++ b/src/components/Form/FormField.jsx
@@ -140,6 +140,7 @@ class FormField extends React.Component {
           onUpdateInput={this.handleUpdateInput}
           searchText={searchText}
           errorText={errorText}
+          listStyle={{ maxHeight: 250, overflow: 'auto' }}
           style={{ flex: '1 0 0' }}
           floatingLabelFocusStyle={{ color: errorText ? colorRed : colorBlue }}
           underlineFocusStyle={{ borderColor: colorBlue }}


### PR DESCRIPTION
fixes #1402 

I added list styling to the options for the autocomplete inside the form component. This resolves the dropdown overflowing in issue #1402. 