### PR TITLE
Retain search query in search bar after refresh

### DIFF
--- a/src/components/Search/SearchForm.jsx
+++ b/src/components/Search/SearchForm.jsx
@@ -23,6 +23,9 @@ class SearchForm extends React.Component {
     const { pathname } = window.location;
     if (params.q && pathname === '/search') {
       this.props.dispatchSearch(params.q);
+      this.setState({
+        query: params.q,
+      });
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/odota/web/issues/1447

Now value of search bar will be filled before mount with the value of the search query in the parameter.