### PR TITLE
Issue/1446 add pagination info to url

### DIFF
--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import constants from '../constants';
+import querystring from 'querystring';
 
 const StyledMain = styled.main`
   position: relative;
@@ -47,6 +48,13 @@ const StyledSection = styled.section`
   }
 `;
 
+const filteredURLSearchParams = () => {
+  const PARAMS_TO_IGNORE = [constants.PAGINATION_PAGE_NUMBER, constants.PAGINATION_PAGE_SIZE];
+  const params = querystring.parse(window.location.search.substring(1));
+  PARAMS_TO_IGNORE.forEach(key => delete params[key]);
+  return querystring.encode(params);
+};
+
 const TabBar = ({ tabs, info }) => (
   <StyledMain>
     <StyledSection>
@@ -54,7 +62,7 @@ const TabBar = ({ tabs, info }) => (
         <Link
           key={`${tab.name}_${tab.route}_${tab.key}`}
           className={tab.key === info ? 'chosen' : ''}
-          to={tab.route + window.location.search}
+          to={tab.route + filteredURLSearchParams()}
           disabled={tab.disabled}
         >
           {tab.name}

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import constants from '../constants';
 import querystring from 'querystring';
+import constants from '../constants';
 
 const StyledMain = styled.main`
   position: relative;

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -52,7 +52,7 @@ const filteredURLSearchParams = () => {
   const PARAMS_TO_IGNORE = [constants.PAGINATION_PAGE_NUMBER, constants.PAGINATION_PAGE_SIZE];
   const params = querystring.parse(window.location.search.substring(1));
   PARAMS_TO_IGNORE.forEach(key => delete params[key]);
-  return querystring.encode(params);
+  return '?' + querystring.encode(params);
 };
 
 const TabBar = ({ tabs, info }) => (

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -52,7 +52,7 @@ const filteredURLSearchParams = () => {
   const PARAMS_TO_IGNORE = [constants.PAGINATION_PAGE_NUMBER, constants.PAGINATION_PAGE_SIZE];
   const params = querystring.parse(window.location.search.substring(1));
   PARAMS_TO_IGNORE.forEach(key => delete params[key]);
-  return '?' + querystring.encode(params);
+  return `?${querystring.encode(params)}`;
 };
 
 const TabBar = ({ tabs, info }) => (

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import querystring from 'querystring';
 import constants from '../constants';
+import { PAGINATION_PAGE_NUMBER, PAGINATION_PAGE_SIZE } from '../keys';
 
 const StyledMain = styled.main`
   position: relative;
@@ -49,7 +50,7 @@ const StyledSection = styled.section`
 `;
 
 const filteredURLSearchParams = () => {
-  const PARAMS_TO_IGNORE = [constants.PAGINATION_PAGE_NUMBER, constants.PAGINATION_PAGE_SIZE];
+  const PARAMS_TO_IGNORE = [PAGINATION_PAGE_NUMBER, PAGINATION_PAGE_SIZE];
   const params = querystring.parse(window.location.search.substring(1));
   PARAMS_TO_IGNORE.forEach(key => delete params[key]);
   return `?${querystring.encode(params)}`;

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -9,8 +9,8 @@ import {
 } from 'material-ui/Table';
 import { TablePercent } from 'components/Visualizations';
 import querystring from 'querystring';
-import Pagination from './PaginatedTable/Pagination';
 import { abbreviateNumber, SORT_ENUM, defaultSort } from 'utility';
+import Pagination from './PaginatedTable/Pagination';
 import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
@@ -312,7 +312,6 @@ Table.propTypes = {
   maxRows: number,
   paginated: bool,
   placeholderMessage: string,
-  pageLength: number,
 };
 
 export default Table;

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -15,6 +15,7 @@ import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
 import { StyledBody, StyledContainer } from './Styled';
+import { PAGINATION_PAGE_NUMBER, PAGINATION_PAGE_SIZE } from '../keys';
 
 const getColumnMax = (data, field, getValue) => {
   const valuesArr = data.reduce((arr, row) => {
@@ -67,12 +68,12 @@ const updateURLQueryStringParam = function (key, value) {
 };
 
 const getPageNumberFromURL = () => {
-  const page = getParamFromURL('page');
+  const page = getParamFromURL(PAGINATION_PAGE_NUMBER);
   return page ? page - 1 : 0;
 };
 
 const getPageLengthFromURL = () => {
-  const length = getParamFromURL('pageSize');
+  const length = getParamFromURL(PAGINATION_PAGE_SIZE);
   return length || 20;
 };
 

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -120,7 +120,7 @@ class Table extends React.Component {
   }
   setCurrentPage(pageNumber) {
     // update the URL with page number as the user sees it (1 indexed vs 0 indexed)
-    updateURLQueryStringParam('page', pageNumber + 1);
+    updateURLQueryStringParam(PAGINATION_PAGE_NUMBER, pageNumber + 1);
     this.setState({
       ...this.state,
       currentPage: pageNumber,

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -49,4 +49,6 @@ export default {
   navDrawerWidth: '256px',
   normalTransition: 'all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
   linearTransition: 'all 300ms linear',
+  PAGINATION_PAGE_NUMBER: 'page',
+  PAGINATION_PAGE_SIZE: 'pageSize',
 };

--- a/src/components/keys.js
+++ b/src/components/keys.js
@@ -1,0 +1,2 @@
+export const PAGINATION_PAGE_NUMBER = 'page';
+export const PAGINATION_PAGE_SIZE = 'size';


### PR DESCRIPTION
This is in response to issue #1446 where we want to be able to track the current page and size in the URL. This makes it possible to share the current page with others. Not totally familiar with how React works, but this was P much out of react land. 

Something worth noting is that this PR now allows users to be able to change the Pagination size, if they add `pageSize` to the URL. I can comment out that code for the meantime, since there's currently no comparable feature in the UI.

Bug Found: In doing this, I found a bug that state of the Table is saved between Matches and Heroes tab, meaning if you select page 155 on Matches and go to Heroes, it will result in no results being shown. Will file an issue and solve on a separate ticket. (Ticket is #1460 )

Would like some feedback as to where to put the query keys. They're in the constants.js file, but that looks like its more for CSS styling... can create a new file or something if there isn't one already.