### PR TITLE
Make ability target icons display correctly on small screens

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -947,6 +947,13 @@ const valueStyle = {
   backgroundColor: constants.darkPrimaryColor,
 };
 
+const iconStyle = {
+  height: '30px',
+  bottom: '30px',
+  left: '25px',
+  position: 'relative',
+};
+
 const targetTooltip = (t) => {
   const targets = [];
   Object.keys(t).forEach((target) => {
@@ -957,9 +964,7 @@ const targetTooltip = (t) => {
         <img
           src={heroicon}
           alt=""
-          style={{
- height: '30px', bottom: '30px', left: '25px', position: 'relative',
-}}
+          style={iconStyle}
         />
       </div>
     );

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -940,9 +940,10 @@ export const inflictorsColumns = [
 const sumValues = f => Object.values(f).reduce((a, b) => a + b);
 
 const valueStyle = {
-  position: 'relative',
-  left: '40px',
+  position: 'absolute',
+  left: '35px',
   bottom: '24px',
+  fontSize: '12px',
   zIndex: '1',
   backgroundColor: constants.darkPrimaryColor,
 };
@@ -959,7 +960,7 @@ const targetTooltip = (t) => {
   Object.keys(t).forEach((target) => {
     const heroicon = heroes[getHeroesById()[target].id] && process.env.REACT_APP_API_HOST + heroes[getHeroesById()[target].id].icon;
     const j = (
-      <div style={{ float: 'left' }}>
+      <div style={{ float: 'left', position: 'relative', paddingLeft: '10px' }}>
         <span style={valueStyle}>{`${t[target]}x`}</span>
         <img
           src={heroicon}

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -940,11 +940,10 @@ export const inflictorsColumns = [
 const sumValues = f => Object.values(f).reduce((a, b) => a + b);
 
 const valueStyle = {
-  position: 'absolute',
-  textAlign: 'center',
-  marginLeft: '16px',
-  marginTop: '18px',
-  fontSize: '12px',
+  position: 'relative',
+  left: '40px',
+  bottom: '24px',
+  zIndex: '1',
   backgroundColor: constants.darkPrimaryColor,
 };
 
@@ -953,15 +952,15 @@ const targetTooltip = (t) => {
   Object.keys(t).forEach((target) => {
     const heroicon = heroes[getHeroesById()[target].id] && process.env.REACT_APP_API_HOST + heroes[getHeroesById()[target].id].icon;
     const j = (
-
-      <div style={{ display: 'inline-block', paddingBottom: '20px' }}>
+      <div style={{float: 'left'}}>
         <span style={valueStyle}>{`${t[target]}x`}</span>
         <img
           src={heroicon}
           alt=""
-          style={{ height: '30px', paddingLeft: '15px' }}
+          style={{ height: '30px', bottom: '30px', left: '25px', position: 'relative' }}
         />
-      </div>);
+      </div>
+      );
     targets.push([j, t[target]]);
   });
 
@@ -990,7 +989,9 @@ export const castsColumns = [
         });
 
         return (
-          <div style={{ display: 'inline-block', width: '150px' }}>{r}</div>
+          <ul>
+          {r.map(row => <li style={{clear: 'left'}}>{row}</li>)}
+          </ul>
         );
       }
       return null;

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -952,15 +952,17 @@ const targetTooltip = (t) => {
   Object.keys(t).forEach((target) => {
     const heroicon = heroes[getHeroesById()[target].id] && process.env.REACT_APP_API_HOST + heroes[getHeroesById()[target].id].icon;
     const j = (
-      <div style={{float: 'left'}}>
+      <div style={{ float: 'left' }}>
         <span style={valueStyle}>{`${t[target]}x`}</span>
         <img
           src={heroicon}
           alt=""
-          style={{ height: '30px', bottom: '30px', left: '25px', position: 'relative' }}
+          style={{
+ height: '30px', bottom: '30px', left: '25px', position: 'relative',
+}}
         />
       </div>
-      );
+    );
     targets.push([j, t[target]]);
   });
 
@@ -990,7 +992,7 @@ export const castsColumns = [
 
         return (
           <ul>
-          {r.map(row => <li style={{clear: 'left'}}>{row}</li>)}
+            {r.map(row => <li style={{ clear: 'left' }}>{row}</li>)}
           </ul>
         );
       }


### PR DESCRIPTION
currently they're just overflowing the column on the right if the screen is too small