### PR TITLE
Fetch small hero images in tables instead of full size ones

### DIFF
--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -222,6 +222,16 @@ export const percentile = (pct) => {
   };
 };
 
+export const IMAGESIZE_ENUM = {
+  SMALL: 'sb.png', //     ~10KB (59 px x 33 px)
+  MEDIUM: 'lg.png', //     ~41KB (205 px x 105 px)
+  LARGE: 'full.png', // ~52KB (256 px x 144 px)
+  VERT: 'vert.jpg', // ~18KB (235 px x 272 px) note that this is a jpg
+
+// if you ever wanna see what the above look like (change the suffix):
+// https://api.opendota.com/apps/dota2/images/heroes/abaddon_full.png
+};
+
 const getSubtitle = (row) => {
   if (row.match_id && row.player_slot !== undefined) {
     let laneName;
@@ -243,6 +253,7 @@ const getTitle = (row, col, heroName) => {
   return <TableLink to={`/heroes/${row[col.field]}`}>{heroName}</TableLink>;
 };
 
+
 /**
  * Transformations of table cell data to display values.
  * These functions are intended to be used as the displayFn property in table columns.
@@ -250,12 +261,14 @@ const getTitle = (row, col, heroName) => {
  * */
 // TODO - these more complicated ones should be factored out into components
 export const transformations = {
-  hero_id: (row, col, field, showPvgnaGuide = false) => {
+  hero_id: (row, col, field, showPvgnaGuide = false, imageSizeSuffix = IMAGESIZE_ENUM.SMALL) => {
     const heroName = heroes[row[col.field]] ? heroes[row[col.field]].localized_name : strings.general_no_hero;
+    const imageUrl = heroes[row[col.field]] && process.env.REACT_APP_API_HOST + heroes[row[col.field]].img; // "[api url]/abaddon_full.png?"
+    const imageUrlNoSuffix = imageUrl.slice(0, -('full.png?'.length)); // "[api url]/abaddon"
     return (
       <TableHeroImage
         parsed={row.version}
-        image={heroes[row[col.field]] && process.env.REACT_APP_API_HOST + heroes[row[col.field]].img}
+        image={imageUrlNoSuffix + imageSizeSuffix}
         title={getTitle(row, col, heroName)}
         subtitle={getSubtitle(row)}
         heroName={heroName}
@@ -266,6 +279,11 @@ export const transformations = {
     );
   },
   hero_id_with_pvgna_guide: (row, col, field) => transformations.hero_id(row, col, field, true),
+  hero_id_with_custom_image_size: (row, col, field, showPvgnaGuide, imageSizeSuffix = IMAGESIZE_ENUM.LARGE) => {
+    const heroId = transformations.hero_id(row, col, field, showPvgnaGuide); // image here is [api link]/heroname_full.png, ~34KB (256 px x 144 px)
+    const heroImageURLNoSuffix = heroId.img.slice(0, -('_full.png?'.length));
+    return React.cloneElement(heroId, { image: heroImageURLNoSuffix + imageSizeSuffix });
+  },
   match_id: (row, col, field) => <Link to={`/matches/${field}`}>{field}</Link>,
   match_id_with_time: (row, col, field) => (
     <div>

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -279,11 +279,6 @@ export const transformations = {
     );
   },
   hero_id_with_pvgna_guide: (row, col, field) => transformations.hero_id(row, col, field, true),
-  hero_id_with_custom_image_size: (row, col, field, showPvgnaGuide, imageSizeSuffix = IMAGESIZE_ENUM.LARGE) => {
-    const heroId = transformations.hero_id(row, col, field, showPvgnaGuide); // image here is [api link]/heroname_full.png, ~34KB (256 px x 144 px)
-    const heroImageURLNoSuffix = heroId.img.slice(0, -('_full.png?'.length));
-    return React.cloneElement(heroId, { image: heroImageURLNoSuffix + imageSizeSuffix });
-  },
   match_id: (row, col, field) => <Link to={`/matches/${field}`}>{field}</Link>,
   match_id_with_time: (row, col, field) => (
     <div>


### PR DESCRIPTION
Right now, tables that contain hero images (mainly the Heroes page) use the **~70KB** full size hero image for each hero. This big image is then shrunk with css to a small size.

This is wasteful because Dota 2 api provides small size images that are **~10KB.** 

What I did is so the hero_id transformation changes it's hero image to the small version:

- what was fetched (https://api.opendota.com/apps/dota2/images/heroes/abaddon_full.png)
- what is fetched now (- what was fetched (https://api.opendota.com/apps/dota2/images/heroes/abaddon_sb.png)

On opendota.com, the images on the heroes page in the **Public** tab with cached images weigh **15mb** (~25 if not). With this, the heroes page downloads **~3mb** of images if no cached images are present.

Since heroId is only a row function and is only used in tables, the imageSizeSuffix argument seems pretty useless and it should just be hard coded into the function to fetch the small _sb.png always (because the other image sizes like _vert.png won't be needed). I'm not sure though. Let me know what you think.

I also made this **IMAGESIZE_ENUM** but then realized that I don't see anyone working with anything else than _full and _sb, but maybe it could be used somewhere else later on? Let me know if I should remove it though.