### PR TITLE
Add option to generate unique component keys for table rows

### DIFF
--- a/src/components/Match/TeamTable.jsx
+++ b/src/components/Match/TeamTable.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import Table from 'components/Table';
 import PicksBans from './Overview/PicksBans'; // Displayed only on `Overview` page
 
-const uniqueKey = row => row && row.player_slot + 1;
+const keyFn = row => row && row.player_slot + 1;
 
 const getHighlightFn = loggedInId => row => loggedInId && row.account_id === loggedInId;
 
@@ -31,13 +31,13 @@ const TeamTable = ({
       title={`${getTeamName(radiantTeam, true)} - ${heading}`}
       icon={<IconRadiant />}
     />
-    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
+    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} keyFn={keyFn} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 0)} /> /* team 0 - radiant */}
     <Heading
       title={`${getTeamName(direTeam, false)} - ${heading}`}
       icon={<IconDire />}
     />
-    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
+    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} keyFn={keyFn} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 1)} /> /* team 1 - dire */}
   </div>
 );

--- a/src/components/Match/TeamTable.jsx
+++ b/src/components/Match/TeamTable.jsx
@@ -7,6 +7,8 @@ import { connect } from 'react-redux';
 import Table from 'components/Table';
 import PicksBans from './Overview/PicksBans'; // Displayed only on `Overview` page
 
+const uniqueKey = row => row && row.player_slot + 1;
+
 const getHighlightFn = loggedInId => row => loggedInId && row.account_id === loggedInId;
 
 const filterMatchPlayers = (players, team = '') =>
@@ -23,7 +25,6 @@ const TeamTable = ({
   summable = false,
   hoverRowColumn = false,
   loggedInId,
-  uniqueKey = false,
 }) => (
   <div>
     <Heading
@@ -51,7 +52,6 @@ TeamTable.propTypes = {
   summable: PropTypes.bool,
   hoverRowColumn: PropTypes.bool,
   loggedInId: PropTypes.number,
-  uniqueKey: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/Match/TeamTable.jsx
+++ b/src/components/Match/TeamTable.jsx
@@ -30,13 +30,13 @@ const TeamTable = ({
       title={`${getTeamName(radiantTeam, true)} - ${heading}`}
       icon={<IconRadiant />}
     />
-    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} hoverRowColumn highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
+    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 0)} /> /* team 0 - radiant */}
     <Heading
       title={`${getTeamName(direTeam, false)} - ${heading}`}
       icon={<IconDire />}
     />
-    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} hoverRowColumn highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
+    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 1)} /> /* team 1 - dire */}
   </div>
 );

--- a/src/components/Match/TeamTable.jsx
+++ b/src/components/Match/TeamTable.jsx
@@ -23,19 +23,20 @@ const TeamTable = ({
   summable = false,
   hoverRowColumn = false,
   loggedInId,
+  uniqueKey = false,
 }) => (
   <div>
     <Heading
       title={`${getTeamName(radiantTeam, true)} - ${heading}`}
       icon={<IconRadiant />}
     />
-    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} />
+    <Table data={filterMatchPlayers(players, 'radiant')} columns={columns} summable={summable} hoverRowColumn highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 0)} /> /* team 0 - radiant */}
     <Heading
       title={`${getTeamName(direTeam, false)} - ${heading}`}
       icon={<IconDire />}
     />
-    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} hoverRowColumn={hoverRowColumn} highlightFn={getHighlightFn(loggedInId)} />
+    <Table data={filterMatchPlayers(players, 'dire')} columns={columns} summable={summable} hoverRowColumn highlightFn={getHighlightFn(loggedInId)} uniqueKey={uniqueKey} />
     {picksBans && <PicksBans data={picksBans.filter(pb => pb.team === 1)} /> /* team 1 - dire */}
   </div>
 );
@@ -50,6 +51,7 @@ TeamTable.propTypes = {
   summable: PropTypes.bool,
   hoverRowColumn: PropTypes.bool,
   loggedInId: PropTypes.number,
+  uniqueKey: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/Match/TeamfightMap/index.jsx
+++ b/src/components/Match/TeamfightMap/index.jsx
@@ -507,7 +507,6 @@ class TeamfightMap extends Component {
                 columns={teamfightColumns}
                 radiantTeam={this.props.match.radiant_team}
                 direTeam={this.props.match.dire_team}
-                uniqueKey
               />
             </div>
           </div>

--- a/src/components/Match/TeamfightMap/index.jsx
+++ b/src/components/Match/TeamfightMap/index.jsx
@@ -507,6 +507,7 @@ class TeamfightMap extends Component {
                 columns={teamfightColumns}
                 radiantTeam={this.props.match.radiant_team}
                 direTeam={this.props.match.dire_team}
+                uniqueKey
               />
             </div>
           </div>

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -10,6 +10,7 @@ import {
 import { TablePercent } from 'components/Visualizations';
 import Pagination from 'components/Table/PaginatedTable/Pagination';
 import { abbreviateNumber, SORT_ENUM, defaultSort } from 'utility';
+import uuid from 'uuid';
 import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
@@ -134,6 +135,7 @@ class Table extends React.Component {
       pageLength = 20,
       hoverRowColumn,
       highlightFn,
+      uniqueKey = false,
     } = this.props;
     const {
       sortState, sortField, sortFn, currentPage,
@@ -176,7 +178,7 @@ class Table extends React.Component {
               </MaterialTableHeader>
               <MaterialTableBody displayRowCheckbox={false} selectable={false}>
                 {data.map((row, index) => (
-                  <MaterialTableRow key={index} style={rowStyle(highlightFn, row)}>
+                  <MaterialTableRow key={(uniqueKey && uuid.v4()) || index} style={rowStyle(highlightFn, row)}>
                     {columns.map((column, colIndex) => {
                       const {
                         field, color, center, displayFn, relativeBars, percentBars,
@@ -301,6 +303,7 @@ Table.propTypes = {
   pageLength: number,
   hoverRowColumn: bool,
   highlightFn: func,
+  uniqueKey: bool,
 };
 
 export default Table;

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -134,7 +134,7 @@ class Table extends React.Component {
       pageLength = 20,
       hoverRowColumn,
       highlightFn,
-      uniqueKey,
+      keyFn,
     } = this.props;
     const {
       sortState, sortField, sortFn, currentPage,
@@ -177,7 +177,7 @@ class Table extends React.Component {
               </MaterialTableHeader>
               <MaterialTableBody displayRowCheckbox={false} selectable={false}>
                 {data.map((row, index) => (
-                  <MaterialTableRow key={(uniqueKey && uniqueKey(row)) || index} style={rowStyle(highlightFn, row)}>
+                  <MaterialTableRow key={(keyFn && keyFn(row)) || index} style={rowStyle(highlightFn, row)}>
                     {columns.map((column, colIndex) => {
                       const {
                         field, color, center, displayFn, relativeBars, percentBars,
@@ -302,7 +302,7 @@ Table.propTypes = {
   pageLength: number,
   hoverRowColumn: bool,
   highlightFn: func,
-  uniqueKey: func,
+  keyFn: func,
 };
 
 export default Table;

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -10,7 +10,6 @@ import {
 import { TablePercent } from 'components/Visualizations';
 import Pagination from 'components/Table/PaginatedTable/Pagination';
 import { abbreviateNumber, SORT_ENUM, defaultSort } from 'utility';
-import uuid from 'uuid';
 import TableHeader from './TableHeader';
 import Spinner from '../Spinner';
 import Error from '../Error';
@@ -135,7 +134,7 @@ class Table extends React.Component {
       pageLength = 20,
       hoverRowColumn,
       highlightFn,
-      uniqueKey = false,
+      uniqueKey,
     } = this.props;
     const {
       sortState, sortField, sortFn, currentPage,
@@ -178,7 +177,7 @@ class Table extends React.Component {
               </MaterialTableHeader>
               <MaterialTableBody displayRowCheckbox={false} selectable={false}>
                 {data.map((row, index) => (
-                  <MaterialTableRow key={(uniqueKey && uuid.v4()) || index} style={rowStyle(highlightFn, row)}>
+                  <MaterialTableRow key={(uniqueKey && uniqueKey(row)) || index} style={rowStyle(highlightFn, row)}>
                     {columns.map((column, colIndex) => {
                       const {
                         field, color, center, displayFn, relativeBars, percentBars,
@@ -303,7 +302,7 @@ Table.propTypes = {
   pageLength: number,
   hoverRowColumn: bool,
   highlightFn: func,
-  uniqueKey: bool,
+  uniqueKey: func,
 };
 
 export default Table;


### PR DESCRIPTION
fixes https://github.com/odota/web/issues/1499


this is to prevent unexpected behavior in all tables where we want to shift around rows. like for the Teamfight table.