### PR TITLE
dynamically import abilities

### DIFF
--- a/src/components/Visualizations/inflictorWithValue.jsx
+++ b/src/components/Visualizations/inflictorWithValue.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import uuid from 'uuid';
 import items from 'dotaconstants/build/items.json';
-import abilities from 'dotaconstants/build/abilities.json';
-import neutralAbilities from 'dotaconstants/build/neutral_abilities.json';
 import styled from 'styled-components';
 import strings from '../../lang';
 import constants from '../constants';
@@ -200,70 +198,97 @@ const tooltipContainer = thing => (
   </div>
 );
 
-export default (inflictor, value, type, ptooltip) => {
-  if (inflictor !== undefined) {
-    const ability = abilities[inflictor];
-    const neutralAbility = neutralAbilities[inflictor];
-    const item = items[inflictor];
-    let image;
-    let tooltip = strings.tooltip_autoattack_other;
-    const ttId = uuid.v4();
+class InflictorWithValue extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
 
-    if (ability) {
-      if (inflictor.includes('attribute_bonus')) {
-        image = '/assets/images/stats.png';
-      } else if (inflictor.includes('special_bonus')) {
-        image = '/assets/images/dota2/talent_tree.svg';
-      } else if (neutralAbility) {
-        image = neutralAbility.img;
-      } else {
-        image = `${process.env.REACT_APP_API_HOST}/apps/dota2/images/abilities/${inflictor}_lg.png`;
-      }
-      tooltip = tooltipContainer(ability);
-    } else if (item) {
-      if (customImageIcon.includes(inflictor)) {
-        image = `/assets/images/dota2/${inflictor}.png`;
-      } else {
-        image = `${process.env.REACT_APP_API_HOST}/apps/dota2/images/items/${getInflictorImage(inflictor)}_lg.png`;
-      }
-      tooltip = tooltipContainer(item);
-    } else {
-      image = '/assets/images/default_attack.png';
-    }
-    if (ptooltip) {
-      tooltip = ptooltip;
-    }
+  async UNSAFE_componentWillMount() {
+    this.setState({
+      abilities: await import('dotaconstants/build/abilities.json'),
+      neutralAbilities: await import('dotaconstants/build/neutral_abilities.json'),
+    });
+  }
 
-    return (
-      <StyledDiv>
-        <div className="inflictorWithValue" data-tip={tooltip && true} data-for={ttId}>
-          {!type &&
-          <object data={image} height="27px" type="image/png">
-            <img src="/assets/images/Dota2Logo.svg" alt="" style={{ filter: 'grayscale(60%)' }} />
-          </object>}
-          {type === 'buff' &&
-          <div
-            className="buff"
-            style={{
+  render() {
+    const {
+      inflictor, value, type, ptooltip,
+    } = this.props;
+    const { abilities, neutralAbilities } = this.state;
+    if (inflictor !== undefined) {
+      const ability = abilities && abilities[inflictor];
+      const neutralAbility = neutralAbilities && neutralAbilities[inflictor];
+      const item = items[inflictor];
+      let image;
+      let tooltip = strings.tooltip_autoattack_other;
+      const ttId = uuid.v4();
+
+      if (ability) {
+        if (inflictor.includes('attribute_bonus')) {
+          image = '/assets/images/stats.png';
+        } else if (inflictor.includes('special_bonus')) {
+          image = '/assets/images/dota2/talent_tree.svg';
+        } else if (neutralAbility) {
+          image = neutralAbility.img;
+        } else {
+          image = `${process.env.REACT_APP_API_HOST}/apps/dota2/images/abilities/${inflictor}_lg.png`;
+        }
+        tooltip = tooltipContainer(ability);
+      } else if (item) {
+        if (customImageIcon.includes(inflictor)) {
+          image = `/assets/images/dota2/${inflictor}.png`;
+        } else {
+          image = `${process.env.REACT_APP_API_HOST}/apps/dota2/images/items/${getInflictorImage(inflictor)}_lg.png`;
+        }
+        tooltip = tooltipContainer(item);
+      } else {
+        image = '/assets/images/default_attack.png';
+      }
+      if (ptooltip) {
+        tooltip = ptooltip;
+      }
+
+      return (
+        <StyledDiv>
+          <div className="inflictorWithValue" data-tip={tooltip && true} data-for={ttId}>
+            {!type &&
+            <object data={image} height="27px" type="image/png">
+              <img src="/assets/images/Dota2Logo.svg" alt="" style={{ filter: 'grayscale(60%)' }} />
+            </object>}
+            {type === 'buff' &&
+            <div
+              className="buff"
+              style={{
               backgroundImage: `url(${image})`,
             }}
-          />
+            />
           }
-          {!type && <div className="overlay">{value}</div>}
-          {type === 'buff' &&
-          <div className="buffOverlay">
-            {value > 0 && value}
+            {!type && <div className="overlay">{value}</div>}
+            {type === 'buff' &&
+            <div className="buffOverlay">
+              {value > 0 && value}
+            </div>
+          }
+            {tooltip &&
+            <div className="tooltip">
+              <ReactTooltip id={ttId} effect="solid" place="left">
+                {tooltip}
+              </ReactTooltip>
+            </div>}
           </div>
-          }
-          {tooltip &&
-          <div className="tooltip">
-            <ReactTooltip id={ttId} effect="solid" place="left">
-              {tooltip}
-            </ReactTooltip>
-          </div>}
-        </div>
-      </StyledDiv>
-    );
+        </StyledDiv>
+      );
+    }
+    return null;
   }
-  return null;
+}
+
+InflictorWithValueComp.propTypes = {
+  inflictor: PropTypes.string,
+  value: PropTypes.string,
+  type: PropTypes.string,
+  ptooltip: PropTypes.shape({}),
 };
+
+export default (inflictor, value, type, ptooltip) => <InflictorWithValue inflictor={inflictor} value={value} type={type} ptooltip={ptooltip} />;

--- a/src/components/Visualizations/inflictorWithValue.jsx
+++ b/src/components/Visualizations/inflictorWithValue.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 import uuid from 'uuid';
 import items from 'dotaconstants/build/items.json';
@@ -284,7 +285,7 @@ class InflictorWithValue extends React.Component {
   }
 }
 
-InflictorWithValueComp.propTypes = {
+InflictorWithValue.propTypes = {
   inflictor: PropTypes.string,
   value: PropTypes.string,
   type: PropTypes.string,


### PR DESCRIPTION
a better version of https://github.com/odota/web/pull/1241

This uses dynamic import to only load the abilities on demand.

A similar approach can be taken for items, heroes, etc., but I only did abilities here because:
* It's the biggest chunk
* It's only used in one place

This approach should theoretically be extensible to allow fetching files in different languages, the goal of #338 