### PR TITLE
replace spinners with skeletons on player page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11754,6 +11754,11 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-content-loader": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-3.1.1.tgz",
+      "integrity": "sha512-TYjNdrapQE0Eg34OUbNFrPBChVxhKmRk/7NzGIhdbP+L0/KfirGzNcBDJjgVBJH18cGSDQ98248YGwB9b7fbVw=="
+    },
     "react-dev-utils": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "material-ui": "^0.19.4",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
+    "react-content-loader": "^3.1.1",
     "react-dom": "^16.3.2",
     "react-ga": "^2.5.0",
     "react-helmet": "^5.2.0",

--- a/src/components/Container/index.jsx
+++ b/src/components/Container/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { List } from 'react-content-loader';
 import Heading from '../Heading';
-import Spinner from '../Spinner';
 import Error from '../Error';
 
 export const AsyncContainer = ({ loading, error, children }) => {
@@ -9,7 +9,7 @@ export const AsyncContainer = ({ loading, error, children }) => {
     return <Error />;
   }
   if (loading) {
-    return <Spinner />;
+    return <List />;
   }
   return children;
 };

--- a/src/components/Player/Header/PlayerHeader.jsx
+++ b/src/components/Player/Header/PlayerHeader.jsx
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 import Avatar from 'material-ui/Avatar';
 import Badge from 'material-ui/Badge';
 import styled from 'styled-components';
+import { Facebook } from 'react-content-loader';
 import { rankTierToString } from '../../../utility';
 import strings from '../../../lang';
 import Error from '../../Error';
-import Spinner from '../../Spinner';
 import PlayerStats from './PlayerStats';
 import PlayerBadges from './PlayerBadges';
 import PlayerButtons from './PlayerButtons';
@@ -220,7 +220,7 @@ const PlayerHeader = ({
     return <Error />;
   }
   if (loading) {
-    return <Spinner />;
+    return <Facebook />;
   }
 
   let badgeStyle = {


### PR DESCRIPTION
references #1407

react-content-loader seems like the most appropriate choice so these changes point in that direction. the PlayerHeader edits can be finished by writing a custom skeleton to more closely match the loaded header. the rest of the spinners on the player page are displayed primarily by the Container component, for the moment there's just the List skeleton substituted in for all children, but perhaps typechecking could be done there to load specific custom skeletons.