### PR TITLE
Scenarios: fix bug with table page selection state

### DIFF
--- a/src/components/Scenarios/Scenarios.jsx
+++ b/src/components/Scenarios/Scenarios.jsx
@@ -185,7 +185,7 @@ class Scenarios extends React.Component {
           />
           <Heading title={strings.explorer_results} subtitle={`${data.filter(minSampleSize).length} ${strings.explorer_num_rows}`} />
           <Table
-            key={selectedTab}
+            key={selectedTab + JSON.stringify(data && data[0])}
             data={data.filter(minSampleSize)}
             columns={getColumns(selectedTab, metadata)}
             loading={scenariosState[selectedTab].loading}

--- a/src/components/Scenarios/Scenarios.jsx
+++ b/src/components/Scenarios/Scenarios.jsx
@@ -185,11 +185,12 @@ class Scenarios extends React.Component {
           />
           <Heading title={strings.explorer_results} subtitle={`${data.filter(minSampleSize).length} ${strings.explorer_num_rows}`} />
           <Table
-            key={selectedTab + JSON.stringify(data && data[0])}
+            key={selectedTab}
             data={data.filter(minSampleSize)}
             columns={getColumns(selectedTab, metadata)}
             loading={scenariosState[selectedTab].loading}
             paginated
+            resetTableState
           />
         </div>
         }


### PR DESCRIPTION
Finally figured out what was going on.

Page selection state of the table component would not reset on a new query. So if you selected page 3 but your result only had a single page then it would not display anything.