### PR TITLE
Improved Frontend for Player Totals (Records)

### DIFF
--- a/src/components/Player/Pages/Totals/Card.jsx
+++ b/src/components/Player/Pages/Totals/Card.jsx
@@ -37,13 +37,13 @@ const Wrapper = styled.div`
   @media screen and (max-width: 380px) {
     width: 100%;
   }
-`
+`;
 
 const Box = styled.div`
   border-radius: 4px;
   border: 1px solid rgba(0, 0, 0, .35);
   overflow: hidden;
-`
+`;
 
 const Header = styled.div`
   background: rgba(0, 0, 0, .15);
@@ -55,16 +55,16 @@ const Header = styled.div`
   text-align: center;
   text-shadow: 0 1px 1px rgba(0, 0, 0, .2);
   text-transform: uppercase;
-`
+`;
 
 const Value = styled.div`
   font-size: 12px;
   line-height: 1;
   padding: 16px 12px;
   text-align: center;
-`
+`;
 
-const Card = ({total}) => (
+const Card = ({ total }) => (
   <Wrapper>
     <Box>
       <Header>{strings[`heading_${total.field}`]}</Header>
@@ -74,7 +74,7 @@ const Card = ({total}) => (
 );
 
 Card.propTypes = {
-  total: shape({})
-}
+  total: shape({}),
+};
 
 export default Card;

--- a/src/components/Player/Pages/Totals/Card.jsx
+++ b/src/components/Player/Pages/Totals/Card.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import styled from 'styled-components';
+import { shape } from 'prop-types';
+import strings from '../../../../lang';
+
+// Strings are in format e.g. '%d seconds'
+const getAbbrTime = str => str.slice(3, 4);
+
+const formatDurationString = (sec) => {
+  const days = Math.floor(sec / 86400);
+  const hours = Math.floor((sec - (days * 86400)) / 3600);
+  const minutes = Math.floor((sec - (days * 86400) - (hours * 3600)) / 60);
+  const seconds = Math.floor((sec - (days * 86400) - (hours * 3600) - (minutes * 60)));
+  return `${days}${getAbbrTime(strings.time_dd)} ${hours}${getAbbrTime(strings.time_hh)} ${minutes}${getAbbrTime(strings.time_mm)} ${seconds}${getAbbrTime(strings.time_ss)}`;
+};
+
+const Wrapper = styled.div`
+  box-sizing: border-box;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  padding-left: 8px;
+  padding-right: 8px;
+  width: 20%;
+
+  @media screen and (max-width: 1000px) {
+    width: 25%;
+  }
+
+  @media screen and (max-width: 850px) {
+    width: 33.333%;
+  }
+
+  @media screen and (max-width: 560px) {
+    width: 50%;
+  }
+
+  @media screen and (max-width: 380px) {
+    width: 100%;
+  }
+`
+
+const Box = styled.div`
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, .35);
+  overflow: hidden;
+`
+
+const Header = styled.div`
+  background: rgba(0, 0, 0, .15);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  line-height: 1;
+  padding: 16px 12px;
+  text-align: center;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, .2);
+  text-transform: uppercase;
+`
+
+const Value = styled.div`
+  font-size: 12px;
+  line-height: 1;
+  padding: 16px 12px;
+  text-align: center;
+`
+
+const Card = ({total}) => (
+  <Wrapper>
+    <Box>
+      <Header>{strings[`heading_${total.field}`]}</Header>
+      <Value>{total.field === 'duration' ? formatDurationString(total.sum) : Math.floor(total.sum).toLocaleString()}</Value>
+    </Box>
+  </Wrapper>
+);
+
+Card.propTypes = {
+  total: shape({})
+}
+
+export default Card;

--- a/src/components/Player/Pages/Totals/Totals.jsx
+++ b/src/components/Player/Pages/Totals/Totals.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { CardTitle } from 'material-ui/Card';
 // import util from 'util';
+import Card from './Card'
 import { getPlayerTotals } from '../../../../actions';
 import Container from '../../../Container';
 import strings from '../../../../lang';
+
+const CardContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: -8px;
+  margin-right: -8px;
+`
 
 const totalsToShow = {
   kills: 1,
@@ -30,24 +38,9 @@ const totalsToShow = {
   pings: 'parsed',
 };
 
-// Strings are in format e.g. '%d seconds'
-const getAbbrTime = str => str.slice(3, 4);
-
-const formatDurationString = (sec) => {
-  const days = Math.floor(sec / 86400);
-  const hours = Math.floor((sec - (days * 86400)) / 3600);
-  const minutes = Math.floor((sec - (days * 86400) - (hours * 3600)) / 60);
-  const seconds = Math.floor((sec - (days * 86400) - (hours * 3600) - (minutes * 60)));
-  return `${days}${getAbbrTime(strings.time_dd)} ${hours}${getAbbrTime(strings.time_hh)} ${minutes}${getAbbrTime(strings.time_mm)} ${seconds}${getAbbrTime(strings.time_ss)}`;
-};
-
 const drawElement = (element, type) => {
   if (totalsToShow[element.field] === type) {
-    return (
-      <CardTitle
-        subtitle={<div>{element.field === 'duration' ? formatDurationString(element.sum) : Math.floor(element.sum).toLocaleString()}</div>}
-        title={strings[`heading_${element.field}`]}
-      />);
+    return <Card total={element} />
   }
   return null;
 };
@@ -55,14 +48,14 @@ const drawElement = (element, type) => {
 const Totals = ({ data, error, loading }) => (
   <div>
     <Container title={strings.heading_all_matches} error={error} loading={loading}>
-      <div>
+      <CardContainer>
         {data.map(element => drawElement(element, 1))}
-      </div>
+      </CardContainer>
     </Container>
     <Container title={strings.heading_parsed_matches} error={error} loading={loading}>
-      <div>
+      <CardContainer>
         {data.map(element => drawElement(element, 'parsed'))}
-      </div>
+      </CardContainer>
     </Container>
   </div>);
 

--- a/src/components/Player/Pages/Totals/Totals.jsx
+++ b/src/components/Player/Pages/Totals/Totals.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // import util from 'util';
-import Card from './Card'
+import Card from './Card';
 import { getPlayerTotals } from '../../../../actions';
 import Container from '../../../Container';
 import strings from '../../../../lang';
@@ -13,7 +13,7 @@ const CardContainer = styled.div`
   flex-wrap: wrap;
   margin-left: -8px;
   margin-right: -8px;
-`
+`;
 
 const totalsToShow = {
   kills: 1,
@@ -40,7 +40,7 @@ const totalsToShow = {
 
 const drawElement = (element, type) => {
   if (totalsToShow[element.field] === type) {
-    return <Card total={element} />
+    return <Card total={element} />;
   }
   return null;
 };


### PR DESCRIPTION
I improved the look of the Totals page which was just a stacked list of totals before.

![image](https://user-images.githubusercontent.com/6538827/39407695-3178eab6-4bca-11e8-9c6a-2033ef2c6fee.png)

---

Before:

![image](https://user-images.githubusercontent.com/6538827/39407704-602b702c-4bca-11e8-91cf-cbc75e2d1a72.png)

