### PR TITLE
Fix URL to blog post re MMR not being up to date

### DIFF
--- a/src/components/Player/Pages/MMR/MMR.jsx
+++ b/src/components/Player/Pages/MMR/MMR.jsx
@@ -8,7 +8,7 @@ import Info from '../../../Alerts/Info';
 
 const MMRInfo = strings => (
   <Info>
-    <a href="https://blog.opendota.com/2016/01/13/opendota-mmr-and-you/" target="_blank" rel="noopener noreferrer">
+    <a href="https://blog.opendota.com/2016/01/12/opendota-mmr-and-you/" target="_blank" rel="noopener noreferrer">
       {strings.mmr_not_up_to_date}
     </a>
   </Info>);


### PR DESCRIPTION
Datestamp in the URL pointing at the MMR blog post is out by 1 day

Appreciate this is old news now because mmr cant be tracked this way, but the current link is 404