### PR TITLE
Increase buildings contrast on buildings map

### DIFF
--- a/src/components/Match/BuildingMap/BuildingMap.jsx
+++ b/src/components/Match/BuildingMap/BuildingMap.jsx
@@ -321,7 +321,7 @@ const BuildingMap = ({ match, strings }) => {
               (type === 'fort' && 25) ||
               (type === 'tower' && 16) ||
               (type.includes('rax') && 12),
-            opacity: bits[i] === '1' || '0.4',
+            filter: bits[i] === '1' ? 'contrast(150%)' : 'grayscale(100%) brightness(70%)',
           },
         },
       };


### PR DESCRIPTION
The solution with opacity is really difficult to read, especially on the radiant side.