### PR TITLE
Added lane outcome to the hero tooltips!

### DIFF
--- a/src/components/Match/BuildingMap/BuildingMap.jsx
+++ b/src/components/Match/BuildingMap/BuildingMap.jsx
@@ -439,7 +439,25 @@ const BuildingMap = ({ match, strings }) => {
     const roaming = (
       <span className="roaming">{strings.roaming}</span>
     );
+
+    const getLaneScore = players => (Math.max(...players.map(player => player.gold_t[10] || 0)) || 0);
+    const laneScoreDraw = 500;
+
     for (let i = 0; i < match.players.length; i += 1) {
+      const { lane } = match.players[i];
+      const radiantPlayers = match.players.filter(player => player.lane === parseInt(lane, 10) && player.isRadiant && (!player.is_roaming));
+      const direPlayers = match.players.filter(player => player.lane === parseInt(lane, 10) && !player.isRadiant && (!player.is_roaming));
+      const bRadiantWon = getLaneScore(radiantPlayers) > getLaneScore(direPlayers);
+      const bIsDraw = Math.abs(getLaneScore(radiantPlayers) - getLaneScore(direPlayers)) <= laneScoreDraw;
+
+      let laneOutcome = strings.td_no_result;
+      if (!bIsDraw) {
+        if (match.players[i].isRadiant) {
+          laneOutcome = bRadiantWon ? strings.td_win : strings.td_loss;
+        } else {
+          laneOutcome = !bRadiantWon ? strings.td_win : strings.td_loss;
+        }
+      }
       const player = (
         <div
           key={heroes[match.players[i].hero_id] && heroes[match.players[i].hero_id].name}
@@ -455,6 +473,8 @@ const BuildingMap = ({ match, strings }) => {
             <br />
             {match.players[i].is_roaming ? roaming : ''}
             {match.players[i].desc}
+            <br />
+            {!(match.players[i].is_roaming) && laneOutcome}
           </ReactTooltip>
         </div>
       );


### PR DESCRIPTION
Fixed #1655 per user request. Waving the mouse over a hero's icon in the match overview's `BuildingMap` component will now have a new line at the bottom of the tooltip pop-up to say either "Win", "Loss", or "No result" based on the outcome of that lane. It is calculated the same way as in the LaneStory class contained in the MatchStory.jsx file.

It is probably better practice to take that part of the LaneStory class out into its own file so that we can refactor and stick to the DRY principle and use indirection, but I don't know what your rules are about adding new files or components, so I just played it safe and ported the functionality directly into this component via hard coding.

I hope this PR request is worthy of acceptance!