### PR TITLE
Remove duplicate in ru translation

### DIFF
--- a/src/lang/ru-RU.json
+++ b/src/lang/ru-RU.json
@@ -64,7 +64,6 @@
   "api_month": "Месяц",
   "api_header_key": "Ваш ключ",
   "api_header_table": "Начните бесплатно. Продолжайте по смехотворно низкой цене.",
-  "api_header_details": "Детали",
   
   "app_name": "OpenDota",
   "app_language": "Язык",


### PR DESCRIPTION
"api_header_details" is already declared on line 49