### PR TITLE
Fixed strings prop not being passed to XPTooltip

### DIFF
--- a/src/components/Visualizations/Graph/MatchGraph.jsx
+++ b/src/components/Visualizations/Graph/MatchGraph.jsx
@@ -107,7 +107,7 @@ const XpNetworthGraph = ({
             opacity={0.5}
           />
 
-          <Tooltip content={<XpTooltipContent />} />
+          <Tooltip content={<XpTooltipContent strings={strings} />} />
           <Line
             dot={false}
             dataKey="rXpAdv"


### PR DESCRIPTION
`strings` prop not being passed was causing the tooltip on the Advantage graph not to be rendered.