### PR TITLE
Fix lane role and party size tooltip

### DIFF
--- a/src/components/Match/TargetsBreakdown.jsx
+++ b/src/components/Match/TargetsBreakdown.jsx
@@ -106,17 +106,11 @@ const TargetsBreakdown = ({ field, abilityUses = null }) => {
     }
     const r = [];
     Object.keys(f).forEach((inflictor) => {
-      const value = (
-        <div>
-          <div id="heroTargetValue">{abbreviateNumber(sumValues(f[inflictor]))}</div>
-          <div id="totalValue">{(abilityUses && abilityUses[inflictor]) || abbreviateNumber(sumValues(f[inflictor]))}</div>
-        </div>
-      );
       r.push((
         <div style={{ display: 'flex' }}>
           {
             <StyledDmgTargetInflictor id="target">
-              {inflictorWithValue(inflictor, value)}
+              {inflictorWithValue(inflictor, abbreviateNumber(sumValues(f[inflictor])))}
             </StyledDmgTargetInflictor>
           }
           {<NavigationArrowForward style={arrowStyle} />}

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -20,7 +20,7 @@ import HeroImage from '../HeroImage';
 const Styled = styled.div`
 
 .hero-tooltip .__react_component_tooltip {
-  opacity: 0.8 !important;
+  opacity: 1 !important;
   padding: 0px !important;
 }
 
@@ -466,7 +466,7 @@ const TableHeroImage = ({
             alt=""
             className="image"
             data-tip={hero.id === undefined && null}
-            data-for={hero.id !== undefined && image}
+            data-for={heroName !== undefined && heroName}
           /> :
           <HeroImage id={heroID} className="image" data-tip={hero.id === undefined && null} data-for={heroName !== undefined && heroName} />
         }

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -466,7 +466,7 @@ const TableHeroImage = ({
             alt=""
             className="image"
             data-tip={hero.id === undefined && null}
-            data-for={heroName !== undefined && heroName}
+            data-for={heroName}
           /> :
           <HeroImage id={heroID} className="image" data-tip={hero.id === undefined && null} data-for={heroName !== undefined && heroName} />
         }

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -613,14 +613,13 @@ export function displayHeroId(row, col, field, showGuide = false, imageSizeSuffi
         <div>
           {row && <span style={{ float: 'left' }}><FromNowTooltip timestamp={row.start_time + row.duration} /></span>}
           {lane ?
-            <img
-              src={`/assets/images/dota2/lane_${lane}.svg`}
-              alt=""
-              data-tip={tooltip}
-              data-offset="{'right': 4, 'top': 4}"
-              data-delay-show="300"
-              style={roleIconStyle}
-            />
+            <span data-hint={tooltip} data-hint-position="top" style={{ float: 'right' }}>
+              <img
+                src={`/assets/images/dota2/lane_${lane}.svg`}
+                alt=""
+                style={roleIconStyle}
+              />
+            </span>
           : ''}
         </div>);
     } else if (row.last_played) {
@@ -735,9 +734,8 @@ export const transformations = {
           </span>
           <span
             style={partyStyle}
-            data-tip={`${strings.filter_party_size} ${row.party_size || strings.game_mode_0}`}
-            data-offset="{'top': 4, 'right' : 8}"
-            data-delay-show="300"
+            data-hint={`${strings.filter_party_size} ${row.party_size || strings.game_mode_0}`}
+            data-hint-position="top"
           >
             {partySize(row.party_size)}
           </span>


### PR DESCRIPTION
the changes in TargetsBreakdown.jsx are because of some weird bug where the browser would freeze up if you hovered over the icons too fast.