### PR TITLE
Add tooltips to Records page

### DIFF
--- a/src/components/Records/index.jsx
+++ b/src/components/Records/index.jsx
@@ -33,6 +33,7 @@ const fields = ['duration', 'kills', 'deaths', 'assists', 'gold_per_min', 'xp_pe
 const tabs = strings => (fields.map(field => ({
   name: strings[`th_${field}`],
   key: field,
+  tooltip: strings[`tooltip_${field}`],
   content: propsPar => (
     <Container>
       <Table

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -63,7 +63,7 @@ const TabBar = ({ tabs, info, match }) => (
           disabled={tab.disabled}
           hidden={tab.hidden && tab.hidden(match)}
         >
-          <div data-tip={tab.tooltip && true} data-for={`tooltip_${tab.key}`}>
+          <div data-tip={tab.tooltip} data-for={`tooltip_${tab.key}`}>
             {tab.name}
             {tab.tooltip &&
             <ReactTooltip id={`tooltip_${tab.key}`} place="top" effect="solid">

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import ReactTooltip from 'react-tooltip';
 import constants from '../constants';
 
 const StyledMain = styled.main`
@@ -62,7 +63,14 @@ const TabBar = ({ tabs, info, match }) => (
           disabled={tab.disabled}
           hidden={tab.hidden && tab.hidden(match)}
         >
-          {tab.name}
+          <div data-tip={tab.tooltip && true} data-for={`tooltip_${tab.key}`}>
+            {tab.name}
+            {tab.tooltip &&
+            <ReactTooltip id={`tooltip_${tab.key}`} place="top" effect="solid">
+              {tab.tooltip}
+            </ReactTooltip>
+            }
+          </div>
         </Link>
       ))}
     </StyledSection>


### PR DESCRIPTION
This partially addresses issue #1342, specifically [this comment](https://github.com/odota/web/issues/1342#issuecomment-386817287).

I enable the TabBar component to show tooltips, if a tooltip is provided. I then add tooltips to the tabs on the "Records" page (i.e. "K", "D", "A", "GPM", "XPM", ...).

I'm a newbie to React -- let me know if anything looks fishy. Cheers.