### PR TITLE
Fix #1883 - Add descending sort to tooltips on match graphs

### DIFF
--- a/src/components/Visualizations/Graph/MatchGraph.jsx
+++ b/src/components/Visualizations/Graph/MatchGraph.jsx
@@ -40,7 +40,7 @@ const CustomizedTooltip = ({ label, payload }) => (
     (
       <div value={data.value} className={`data ${i < 5 && 'isRadiant'}`} style={{ borderLeft: `8px solid ${data.color}` }}>
         {data.dataKey}: {data.value}
-      </div>)).sort((a, b) => a.props.value < b.props.value)
+      </div>)).sort((a, b) => b.props.value - a.props.value)
     }
   </StyledCustomizedTooltip>
 );


### PR DESCRIPTION
This pull request fixes #1883: Graph popups are not sorted by value in descending order

The tooltip when hovering over graphs will now sort correctly.