### PR TITLE
Fixed explorer field to lead properly when strings are not loaded

### DIFF
--- a/src/components/Explorer/ExplorerFormField.jsx
+++ b/src/components/Explorer/ExplorerFormField.jsx
@@ -22,7 +22,7 @@ class ExplorerFormField extends React.Component {
   }
 
   componentDidUpdate(newProps) {
-    if (this.autocomplete && !this.autocomplete.state.searchText) {
+    if (this.autocomplete && this.autocomplete.state) {
       const {
         builderField, builder, fields,
       } = newProps;


### PR DESCRIPTION
Had to delete the previous pr because Github had issues last night and I thought it was my fault. 
Checks for autocomplete.state as well. 