### PR TITLE
Fix duration columns in /matches and /teams/{teamId}/matches

### DIFF
--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -790,12 +790,18 @@ export const transformations = {
   last_played: (row, col, field) => <FromNowTooltip timestamp={field} />,
   duration: (row, col, field) => {
     const { strings } = store.getState().app;
+    const playerSideExists = row && typeof row.player_slot !== 'undefined';
+    const playerIsRadiant = playerSideExists && isRadiant(row.player_slot);
+    const teamSideExists = row && typeof row.radiant !== 'undefined';
+    const teamIsRadiant = teamSideExists && row.radiant;
+    const displaySide = playerSideExists || teamSideExists;
+
     return (
       <div>
         <span>
           {formatSeconds(field)}
         </span>
-        {row && <span style={{ ...subTextStyle }}>{(isRadiant(row.player_slot) ? strings.general_radiant : strings.general_dire)}</span> }
+        {displaySide && <span style={{ ...subTextStyle }}>{playerIsRadiant || teamIsRadiant ? strings.general_radiant : strings.general_dire}</span> }
       </div>
     );
   },


### PR DESCRIPTION
At some point the duration transformation was changed to show also the side the player is on (for example https://opendota.com/players/87278757/matches). Because the transformation is used also in

https://opendota.com/matches
https://opendota.com/teams/1838315

it just shows 'Dire' in situations when it is either incorrect or it doesn't make sense to show anything. I changed it to show the side also on the page that belongs to a specific team. In the matches page when the side info doesn't make sense, it doesn't show anything.