### PR TITLE
Add damage per minute column on Match overview

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -242,16 +242,13 @@ export default (strings) => {
         tooltip: 'Damage per minute',
         sortFn: true,
         sumFn: true,
-        displayFn: row => { 
-            let dmg = row.damage;
-            let total_dmg = Object.keys(dmg).reduce((acc, key) => {
-              return acc + dmg[key];
-            }, 0);
-            let duration_in_seconds = row.duration;
-            let damage_per_second = total_dmg / duration_in_seconds;
-            let damage_per_minute = damage_per_second * 60;
+        displayFn: (row) => {
+          const totalDamage = Object.keys(row.damage).reduce((acc, key) => acc + row.damage[key], 0);
+          const durationInSeconds = row.duration;
+          const damagePerSecond = totalDamage / durationInSeconds;
+          const damagePerMinute = damagePerSecond * 60;
 
-            return Math.round(damage_per_minute);
+          return Math.round(damagePerMinute);
         },
         // relativeBars: true,
         textAlign: 'right',

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -238,6 +238,29 @@ export default (strings) => {
         underline: 'max',
       },
       {
+        displayName: 'DPM',
+        tooltip: 'Damage per minute',
+        sortFn: true,
+        sumFn: true,
+        displayFn: row => { 
+            let dmg = row.damage;
+            let total_dmg = Object.keys(dmg).reduce((acc, key) => {
+              return acc + dmg[key];
+            }, 0);
+            let duration_in_seconds = row.duration;
+            let damage_per_second = total_dmg / duration_in_seconds;
+            let damage_per_minute = damage_per_second * 60;
+
+            return Math.round(damage_per_minute);
+        },
+        // relativeBars: true,
+        textAlign: 'right',
+        paddingLeft: 5,
+        paddingRight: 14,
+        width: 32,
+        borderLeft: '1px solid rgba(19, 19, 19, 0.2)',
+      },
+      {
         displayName: strings.th_hero_damage,
         tooltip: strings.tooltip_hero_damage,
         field: 'hero_damage',


### PR DESCRIPTION
This is for #1842, I've added an extra column to display DPM (Damage per minute).
Please tell me if there's other changes that should be done in order for this PR to be accepted.

Thanks.