### PR TITLE
Sum pings correctly in performances tab

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -75,7 +75,7 @@ class Table extends React.Component {
         {columns.map((column, colIndex) => {
             let total = 0;
             if (column.sumFn) {
-              const sumFn = (typeof column.sumFn === 'function') ? column.sumFn : (acc, row) => (acc + row[column.field]);
+              const sumFn = (typeof column.sumFn === 'function') ? column.sumFn : (acc, row) => (acc + (row[column.field] || 0));
               total = data.reduce(sumFn, null);
             }
 


### PR DESCRIPTION
I noticed that when a player doesn't ping during the game the sum of all pings is not shown correctly, as seen below.
![Shows "-" instead of number](https://user-images.githubusercontent.com/8211902/52156583-422dc800-2670-11e9-8c19-c010ad8a9bb6.png)
This pull request aims to fix that.
