### PR TITLE
Update Percent.jsx

### DIFF
--- a/src/components/Visualizations/Table/Percent.jsx
+++ b/src/components/Visualizations/Table/Percent.jsx
@@ -7,23 +7,28 @@ import constants from '../../constants';
 const Percent = ({
   percent, altValue, valEl, inverse = false,
 }) => (
-  <StyledContainer>
-    <TitleContainer>
-      {valEl || percent} {altValue && <small>{altValue}</small>}
-    </TitleContainer>
-    <PercentContainer>
-      <div
-        style={{
-          width: `${percent}%`,
-          backgroundColor: gradient(percent, {
-            css: true,
-            from: inverse ? constants.colorGreen : constants.colorRed,
-            to: inverse ? constants.colorRed : constants.colorGreen,
-          }),
-        }}
-      />
-    </PercentContainer>
-  </StyledContainer>
+  <React.Fragment>
+    <div style={{ height: 30, display: 'inline-block', verticalAlign: 'middle' }} />
+    <div style={{ display: 'inline-block', width: '100%' }}>
+      <StyledContainer>
+        <TitleContainer>
+          {valEl || percent} {altValue && <small>{altValue}</small>}
+        </TitleContainer>
+        <PercentContainer>
+          <div
+            style={{
+              width: `${percent}%`,
+              backgroundColor: gradient(percent, {
+                css: true,
+                from: inverse ? constants.colorGreen : constants.colorRed,
+                to: inverse ? constants.colorRed : constants.colorGreen,
+              }),
+            }}
+          />
+        </PercentContainer>
+      </StyledContainer>
+    </div>
+  </React.Fragment>
 );
 
 const {


### PR DESCRIPTION
use a fake fill element to stretch the table cell.

fix https://github.com/odota/web/issues/2110

https://deploy-preview-2112--opendota-stage.netlify.com/explorer?minDate=2019-05-05T22%3A00%3A00.000Z&=&group=player&select=kills&limit=&tier=&league=10681&league=10482&league=10810&result=&side=&megaWin=&maxDate=2019-05-09T22%3A00%3A00.000Z&maxDuration=