### PR TITLE
Hide win percentage in histogram label when no games are played

### DIFF
--- a/src/components/Visualizations/Graph/HistogramGraph.jsx
+++ b/src/components/Visualizations/Graph/HistogramGraph.jsx
@@ -21,7 +21,7 @@ const HistogramTooltipContent = ({ payload, xAxisLabel = '', strings }) => {
     <StyledTooltip>
       <div>{`${data && data.x} ${xAxisLabel}`}</div>
       <div>{`${data && data.games} ${strings.th_matches}`}</div>
-      <div>{`${data && (data.win / data.games * 100).toFixed(2)} ${strings.th_win}`}</div>
+      {data && data.games > 0 && <div>{`${(data.win / data.games * 100).toFixed(2)} ${strings.th_win}`}</div>}
     </StyledTooltip>);
 };
 HistogramTooltipContent.propTypes = {


### PR DESCRIPTION
closes #2167 

![image](https://user-images.githubusercontent.com/5839225/62658921-c2b8e280-b98b-11e9-83a1-17e509db6620.png)

keeps old behavior with non-zero amount of games:

![image](https://user-images.githubusercontent.com/5839225/62658948-dc5a2a00-b98b-11e9-86f9-e454bae03d60.png)
