### PR TITLE
Show durations as minutes in trends and history graphs

### DIFF
--- a/src/components/Player/Pages/Histograms/Histograms.jsx
+++ b/src/components/Player/Pages/Histograms/Histograms.jsx
@@ -1,13 +1,14 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+
 import { getPlayerHistograms } from '../../../../actions';
+import ButtonGarden from '../../../ButtonGarden';
+import Container from '../../../Container';
 import Heading from '../../../Heading';
 import { HistogramGraph } from '../../../Visualizations';
-import ButtonGarden from '../../../ButtonGarden';
 import dataColumns from '../matchDataColumns';
-import Container from '../../../Container';
 
 const getMedian = (columns, midpoint) => {
   let sum = 0;
@@ -31,26 +32,26 @@ const histogramNames = dataColumns.filter(col => col !== 'win_rate');
 const Histogram = ({
   routeParams, columns, playerId, error, loading, histogramName, history, strings,
 }) => (
-  <div>
-    <Heading title={strings.histograms_name} subtitle={strings.histograms_description} />
-    <ButtonGarden
-      onClick={(buttonName) => {
-        history.push(`/players/${playerId}/histograms/${buttonName}${window.location.search}`);
-      }}
-      buttonNames={histogramNames}
-      selectedButton={routeParams.subInfo || histogramNames[0]}
-    />
-    <Container error={error} loading={loading}>
-      <div>
-        <Heading
-          title={strings[`heading_${histogramName}`]}
-          subtitle={loading ? '' : [getSubtitleDescription(histogramName, strings), getSubtitleStats(columns, strings)].filter(Boolean).join(' ')}
-        />
-        <HistogramGraph columns={columns || []} />
-      </div>
-    </Container>
-  </div>
-);
+    <div>
+      <Heading title={strings.histograms_name} subtitle={strings.histograms_description} />
+      <ButtonGarden
+        onClick={(buttonName) => {
+          history.push(`/players/${playerId}/histograms/${buttonName}${window.location.search}`);
+        }}
+        buttonNames={histogramNames}
+        selectedButton={routeParams.subInfo || histogramNames[0]}
+      />
+      <Container error={error} loading={loading}>
+        <div>
+          <Heading
+            title={strings[`heading_${histogramName}`]}
+            subtitle={loading ? '' : [getSubtitleDescription(histogramName, strings), getSubtitleStats(columns, strings)].filter(Boolean).join(' ')}
+          />
+          <HistogramGraph columns={columns || []} histogramName={histogramName} />
+        </div>
+      </Container>
+    </div>
+  );
 
 Histogram.propTypes = {
   routeParams: PropTypes.shape({}),

--- a/src/components/Player/Pages/Histograms/Histograms.jsx
+++ b/src/components/Player/Pages/Histograms/Histograms.jsx
@@ -32,26 +32,26 @@ const histogramNames = dataColumns.filter(col => col !== 'win_rate');
 const Histogram = ({
   routeParams, columns, playerId, error, loading, histogramName, history, strings,
 }) => (
-    <div>
-      <Heading title={strings.histograms_name} subtitle={strings.histograms_description} />
-      <ButtonGarden
-        onClick={(buttonName) => {
-          history.push(`/players/${playerId}/histograms/${buttonName}${window.location.search}`);
-        }}
-        buttonNames={histogramNames}
-        selectedButton={routeParams.subInfo || histogramNames[0]}
-      />
-      <Container error={error} loading={loading}>
-        <div>
-          <Heading
-            title={strings[`heading_${histogramName}`]}
-            subtitle={loading ? '' : [getSubtitleDescription(histogramName, strings), getSubtitleStats(columns, strings)].filter(Boolean).join(' ')}
-          />
-          <HistogramGraph columns={columns || []} histogramName={histogramName} />
-        </div>
-      </Container>
-    </div>
-  );
+  <div>
+    <Heading title={strings.histograms_name} subtitle={strings.histograms_description} />
+    <ButtonGarden
+      onClick={(buttonName) => {
+        history.push(`/players/${playerId}/histograms/${buttonName}${window.location.search}`);
+      }}
+      buttonNames={histogramNames}
+      selectedButton={routeParams.subInfo || histogramNames[0]}
+    />
+    <Container error={error} loading={loading}>
+      <div>
+        <Heading
+          title={strings[`heading_${histogramName}`]}
+          subtitle={loading ? '' : [getSubtitleDescription(histogramName, strings), getSubtitleStats(columns, strings)].filter(Boolean).join(' ')}
+        />
+        <HistogramGraph columns={columns || []} histogramName={histogramName} />
+      </div>
+    </Container>
+  </div>
+);
 
 Histogram.propTypes = {
   routeParams: PropTypes.shape({}),

--- a/src/components/Visualizations/Graph/HistogramGraph.jsx
+++ b/src/components/Visualizations/Graph/HistogramGraph.jsx
@@ -1,25 +1,31 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import {
-  XAxis,
-  YAxis,
-  Tooltip,
   Bar,
   BarChart,
   CartesianGrid,
-  Label,
   Cell,
+  Label,
   ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
 } from 'recharts';
-import { hsvToRgb } from '../../../utility';
+
+import { formatGraphValueData, hsvToRgb } from '../../../utility';
 import { StyledTooltip } from './Styled';
 
-const HistogramTooltipContent = ({ payload, xAxisLabel = '', strings }) => {
+const HistogramTooltipContent = ({
+  payload,
+  xAxisLabel = '',
+  strings,
+  histogramName,
+}) => {
   const data = payload && payload[0] && payload[0].payload;
   return (
     <StyledTooltip>
-      <div>{`${data && data.x} ${xAxisLabel}`}</div>
+      <div>{`${formatGraphValueData(data && data.x, histogramName)} ${xAxisLabel}`}</div>
       <div>{`${data && data.games} ${strings.th_matches}`}</div>
       {data && data.games > 0 && <div>{`${(data.win / data.games * 100).toFixed(2)} ${strings.th_win}`}</div>}
     </StyledTooltip>);
@@ -28,22 +34,23 @@ HistogramTooltipContent.propTypes = {
   payload: PropTypes.arrayOf(PropTypes.shape({})),
   xAxisLabel: PropTypes.string,
   strings: PropTypes.shape({}),
+  histogramName: PropTypes.string,
 };
 
 const graphHeight = 400;
 
 const HistogramGraph = ({
-  columns, xAxisLabel = '', strings,
+  columns, xAxisLabel = '', strings, histogramName,
 }) => (
   <ResponsiveContainer width="100%" height={graphHeight}>
     <BarChart
       height={graphHeight}
       data={columns}
       margin={{
-      top: 0, right: 0, left: 0, bottom: 0,
-    }}
+        top: 0, right: 0, left: 0, bottom: 0,
+      }}
     >
-      <XAxis dataKey="x" interval={1}>
+      <XAxis dataKey="x" interval={1} tickFormatter={val => formatGraphValueData(val, histogramName)}>
         <Label value="" position="insideTopRight" />
       </XAxis>
       <YAxis />
@@ -53,7 +60,7 @@ const HistogramGraph = ({
         opacity={0.5}
       />
 
-      <Tooltip content={<HistogramTooltipContent xAxisLabel={xAxisLabel} strings={strings} />} cursor={{ fill: 'rgba(255, 255, 255, .35)' }} />
+      <Tooltip content={<HistogramTooltipContent xAxisLabel={xAxisLabel} strings={strings} />} cursor={{ fill: 'rgba(255, 255, 255, .35)' }} histogramName={histogramName} />
       <Bar
         dataKey="games"
       >
@@ -79,6 +86,7 @@ HistogramGraph.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.shape({})),
   xAxisLabel: PropTypes.string,
   strings: PropTypes.shape({}),
+  histogramName: PropTypes.string,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/Visualizations/Graph/TrendGraph.jsx
+++ b/src/components/Visualizations/Graph/TrendGraph.jsx
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 import heroes from 'dotaconstants/build/heroes.json';
 import styled from 'styled-components';
-import { formatSeconds, fromNow } from '../../../utility';
+import { formatSeconds, fromNow, formatGraphValueData } from '../../../utility';
 import constants from '../../constants';
 import HeroImage from '../HeroImage';
 
@@ -84,7 +84,7 @@ const TrendTooltipContent = ({ payload, name, strings }) => {
         <div className="tooltipWrapper">
           <div className="value">
             {data.name === 'win_rate' ? '' : strings.trends_tooltip_average}
-            {` ${trendStr}: ${Number(data.value.toFixed(2))}${unit}`}
+            {` ${trendStr}: ${formatGraphValueData(Number(data.value.toFixed(2)), name)}${unit}`}
           </div>
           <div className="match">
             <div>
@@ -96,11 +96,11 @@ const TrendTooltipContent = ({ payload, name, strings }) => {
               </div>
               <div>{strings[`game_mode_${data.game_mode}`]}</div>
               <div>{formatSeconds(data.duration)}</div>
-              {data.name === 'win_rate' ? (
+              {data.name === 'win_rate' || name === 'duration' ? (
                 ''
               ) : (
                 <div className="matchValue">
-                  {`${trendStr}: ${Number(data.independent_value.toFixed(2))}${unit}`}
+                  {`${trendStr}: ${formatGraphValueData(Number(data.independent_value.toFixed(2)), name)}${unit}`}
                 </div>
               )}
             </div>

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -1,10 +1,7 @@
-import React from 'react';
-import ReactTooltip from 'react-tooltip';
-import { Link } from 'react-router-dom';
 import heroes from 'dotaconstants/build/heroes.json';
+import itemIds from 'dotaconstants/build/item_ids.json';
 import items from 'dotaconstants/build/items.json';
 import patch from 'dotaconstants/build/patch.json';
-import itemIds from 'dotaconstants/build/item_ids.json';
 import xpLevel from 'dotaconstants/build/xp_level.json';
 import curry from 'lodash/fp/curry';
 import findLast from 'lodash/fp/findLast';
@@ -12,13 +9,17 @@ import inRange from 'lodash/fp/inRange';
 // import SvgIcon from 'material-ui/SvgIcon';
 import SocialPeople from 'material-ui/svg-icons/social/people';
 import SocialPerson from 'material-ui/svg-icons/social/person';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import ReactTooltip from 'react-tooltip';
+
+import constants from '../components/constants';
 import { TableLink } from '../components/Table';
 import {
+  FromNowTooltip,
   KDA,
   TableHeroImage,
-  FromNowTooltip,
 } from '../components/Visualizations';
-import constants from '../components/constants';
 import store from '../store';
 
 const second = 1;
@@ -172,8 +173,8 @@ export const IMAGESIZE_ENUM = {
     height: 272,
   },
 
-// if you ever wanna see what the above look like (change the suffix):
-// https://api.opendota.com/apps/dota2/images/heroes/abaddon_full.png
+  // if you ever wanna see what the above look like (change the suffix):
+  // https://api.opendota.com/apps/dota2/images/heroes/abaddon_full.png
 };
 
 const getTitle = (row, col, heroName) => {
@@ -405,8 +406,8 @@ export const wilsonScore = (up, down) => {
   return (
     phat + ((z * z) / (2 * n)) - (z * Math.sqrt(((phat * (1 - phat)) + (z * z / (4 * n))) / n))
   ) / (
-    1 + (z * z / n)
-  );
+      1 + (z * z / n)
+    );
 };
 
 export const groupBy = (xs, key) =>
@@ -638,7 +639,7 @@ export function displayHeroId(row, col, field, showGuide = false, imageSizeSuffi
                 style={roleIconStyle}
               />
             </span>
-          : ''}
+            : ''}
         </div>);
     } else if (row.last_played) {
       return <FromNowTooltip timestamp={row.last_played} />;
@@ -811,7 +812,7 @@ export const transformations = {
         <span>
           {formatSeconds(field)}
         </span>
-        {displaySide && <span style={{ ...subTextStyle }}>{playerIsRadiant || teamIsRadiant ? strings.general_radiant : strings.general_dire}</span> }
+        {displaySide && <span style={{ ...subTextStyle }}>{playerIsRadiant || teamIsRadiant ? strings.general_radiant : strings.general_dire}</span>}
       </div>
     );
   },
@@ -913,4 +914,16 @@ export function getLocalizedMonthStrings() {
   const langCode = window.localStorage.getItem('localization') || 'en-US';
   const d = new Date();
   return [...Array(12)].map((_, i) => new Date(d.setMonth(i)).toLocaleDateString(langCode, { month: 'short' }));
+}
+
+export function formatGraphValueData(data, histogramName) {
+  if (!data) return '';
+
+  switch (histogramName) {
+    case 'duration':
+      return formatSeconds(data);
+
+    default:
+      return data;
+  }
 }

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -406,8 +406,8 @@ export const wilsonScore = (up, down) => {
   return (
     phat + ((z * z) / (2 * n)) - (z * Math.sqrt(((phat * (1 - phat)) + (z * z / (4 * n))) / n))
   ) / (
-      1 + (z * z / n)
-    );
+    1 + (z * z / n)
+  );
 };
 
 export const groupBy = (xs, key) =>


### PR DESCRIPTION
This should fix issue #2184 while keeping the formatting in the render function of the specific tooltip / graph.

fixes #2184 