### PR TITLE
adds max-width to damage inflictor columns

### DIFF
--- a/src/components/Match/TargetsBreakdown.jsx
+++ b/src/components/Match/TargetsBreakdown.jsx
@@ -87,7 +87,12 @@ const damageTargetIcons = (t) => {
   });
 
   return (
-    <div style={{ paddingRight: '15px', display: 'flex', width: `${30 * 5}px`, flexWrap: 'wrap' }}>
+    <div style={{
+      paddingRight: '15px',
+      display: 'flex',
+      width: `${30 * 5}px`,
+      flexWrap: 'wrap',
+    }}>
       {targets.sort((a, b) => b[1] - a[1]).map(x => x[0])}
     </div>);
 };

--- a/src/components/Match/TargetsBreakdown.jsx
+++ b/src/components/Match/TargetsBreakdown.jsx
@@ -87,7 +87,7 @@ const damageTargetIcons = (t) => {
   });
 
   return (
-    <div style={{ paddingRight: '15px', display: 'flex' }}>
+    <div style={{ paddingRight: '15px', display: 'flex', width: `${30 * 5}px`, flexWrap: 'wrap' }}>
       {targets.sort((a, b) => b[1] - a[1]).map(x => x[0])}
     </div>);
 };
@@ -123,7 +123,7 @@ const TargetsBreakdown = ({ field, abilityUses = null }) => {
     return (
       <StyledDmgTargetRow>
         <div>
-          {r.map(row => <div style={{ display: 'flex', flexDirection: 'column', height: '33px' }} id="row">{row}</div>)}
+          {r.map(row => <div style={{ display: 'flex', flexDirection: 'column' }} id="row">{row}</div>)}
         </div>
       </StyledDmgTargetRow>
     );

--- a/src/components/Match/TargetsBreakdown.jsx
+++ b/src/components/Match/TargetsBreakdown.jsx
@@ -87,12 +87,14 @@ const damageTargetIcons = (t) => {
   });
 
   return (
-    <div style={{
-      paddingRight: '15px',
-      display: 'flex',
-      width: `${30 * 5}px`,
-      flexWrap: 'wrap',
-    }}>
+    <div
+      style={{
+        paddingRight: '15px',
+        display: 'flex',
+        width: `${30 * 5}px`,
+        flexWrap: 'wrap',
+      }}
+    >
       {targets.sort((a, b) => b[1] - a[1]).map(x => x[0])}
     </div>);
 };

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -1061,6 +1061,7 @@ export default (strings) => {
     {
       displayName: strings.th_damage_dealt,
       field: 'damage_targets',
+      width: '1px',
       displayFn: (row, col, field) => {
         if (field) {
           return <TargetsBreakdown field={field} />;


### PR DESCRIPTION
fixes #404

This should fix the issue that damage inflictor columns will take more space in one table than the other. inflicted hero icons should now break after 5 items and should never take more space.

![image](https://user-images.githubusercontent.com/6538827/66269448-c6140180-e848-11e9-8bc6-589db83e99e5.png)

![image](https://user-images.githubusercontent.com/6538827/66269774-1725f480-e84d-11e9-89a1-c9c3c8d22382.png)
