### PR TITLE
2214 navigation rework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,6 +1039,277 @@
       "integrity": "sha512-QsYGKdhhuDFNq7bjm2r44y0mp5xW3uO3csuTPDWZc0OIiMQv+AIY5Cqwd4mJiC5N8estVl7qlvOx1hbtOuUWbw==",
       "dev": true
     },
+    "@material-ui/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UHVAjU+1uDtA+OMBNBHb4RlCZOu514XeYPafNJv+GTdXBDr1SCPK7yqRE6TV1/bulxlDusTgu5Q6BAUgpmO4MA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.5.0",
+        "@material-ui/system": "^4.5.0",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.4.0",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.2",
+        "convert-css-length": "^2.0.1",
+        "deepmerge": "^4.0.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "is-plain-object": "^3.0.0",
+        "normalize-scroll-left": "^0.2.0",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "dom-helpers": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.0.tgz",
+          "integrity": "sha512-zRRYDhpiKuAJHasOqCm7lBnsd22nrM4+OYI4ASWCxen+ocTMl7BIAKgGag97TlLiTl6rrau5aPe1VGUm9jQBng==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "csstype": "^2.6.6"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        },
+        "react-transition-group": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+          "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.4.3.tgz",
+      "integrity": "sha512-HVVvUyc/78kmaBd93LkfWyGkXMM+zOMKzUfulWXxaV/fFAZ3N0pD0oHjWUd94zrOoF3tZP9JC7EPlIpIcZSNow==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.5.0.tgz",
+      "integrity": "sha512-O0NSAECHK9f3DZK6wy56PZzp8b/7KSdfpJs8DSC7vnXUAoMPCTtchBKLzMtUsNlijiJFeJjSxNdQfjWXgyur5A==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.7.1",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "clsx": "^1.0.2",
+        "csstype": "^2.5.2",
+        "deepmerge": "^4.0.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "jss": "^10.0.0",
+        "jss-plugin-camel-case": "^10.0.0",
+        "jss-plugin-default-unit": "^10.0.0",
+        "jss-plugin-global": "^10.0.0",
+        "jss-plugin-nested": "^10.0.0",
+        "jss-plugin-props-sort": "^10.0.0",
+        "jss-plugin-rule-value-function": "^10.0.0",
+        "jss-plugin-vendor-prefixer": "^10.0.0",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@emotion/hash": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
+          "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw=="
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.5.0.tgz",
+      "integrity": "sha512-vR0PbMTzLnuuVCoYNQ13zyhLa/4s/UA9P9JbNuHBOOkfrHn53ShINiG0v05EgfwizfULLtc7mNvsGAgIyyp/hQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "deepmerge": "^4.0.0",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "@material-ui/types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
+      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.4.0.tgz",
+      "integrity": "sha512-UXoQVwArQEQWXxf2FPs0iJGT+MePQpKr0Qh0CPoLc1OdF0GSMTmQczcqCzwZkeHxHAOq/NkIKM1Pb/ih1Avicg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2627,6 +2898,28 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
       "integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==",
       "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/react": {
+      "version": "16.9.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.5.tgz",
+      "integrity": "sha512-jQ12VMiFOWYlp+j66dghOWcmDDwhca0bnlcTxS4Qz/fh5gi6wpaZDthPEu/Gc/YlAuO87vbiUXL8qKstFvuOaA==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.3.tgz",
+      "integrity": "sha512-Hk8jiuT7iLOHrcjKP/ZVSyCNXK73wJAUz60xm0mVhiRujrdiI++j4duLiL282VGxwAgxetHQFfqA29LgEeSkFA==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/tapable": {
       "version": "1.0.2",
@@ -5844,6 +6137,11 @@
         "shallow-clone": "^0.1.2"
       }
     },
+    "clsx": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
+      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6087,6 +6385,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "convert-css-length": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
+      "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -6422,6 +6725,30 @@
       "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
       "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
     },
+    "css-vendor": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.7.tgz",
+      "integrity": "sha512-VS9Rjt79+p7M0WkPqcAza4Yq1ZHrsHrwf7hPL/bjQB+c1lwmAI+1FXxYTYt818D/50fFVflw0XKleiBN5RITkg==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "is-in-browser": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
@@ -6591,6 +6918,11 @@
         "cssom": "0.3.x"
       }
     },
+    "csstype": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
+      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -6738,6 +7070,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deepmerge": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww=="
     },
     "default-gateway": {
       "version": "2.7.2",
@@ -9009,7 +9346,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9027,11 +9365,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9044,15 +9384,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9155,7 +9498,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9165,6 +9509,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9177,17 +9522,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9204,6 +9552,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9276,7 +9625,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9286,6 +9636,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9361,7 +9712,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9391,6 +9743,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9408,6 +9761,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9446,11 +9800,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9666,6 +10022,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gulp-clone": {
       "version": "2.0.1",
@@ -10959,6 +11320,11 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
       "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -11902,6 +12268,208 @@
         "verror": "1.10.0"
       }
     },
+    "jss": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0.tgz",
+      "integrity": "sha512-TPpDFsiBjuERiL+dFDq8QCdiF9oDasPcNqCKLGCo/qED3fNYOQ8PX2lZhknyTiAt3tZrfOFbb0lbQ9lTjPZxsQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^2.6.5",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0.tgz",
+      "integrity": "sha512-yALDL00+pPR4FJh+k07A8FeDvfoPPuXU48HLy63enAubcVd3DnS+2rgqPXglHDGixIDVkCSXecl/l5GAMjzIbA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "hyphenate-style-name": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+          "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0.tgz",
+      "integrity": "sha512-sURozIOdCtGg9ap18erQ+ijndAfEGtTaetxfU3H4qwC18Bi+fdvjlY/ahKbuu0ASs7R/+WKCP7UaRZOjUDMcdQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0.tgz",
+      "integrity": "sha512-80ofWKSQUo62bxLtRoTNe0kFPtHgUbAJeOeR36WEGgWIBEsXLyXOnD5KNnjPqG4heuEkz9eSLccjYST50JnI7Q==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0.tgz",
+      "integrity": "sha512-waxxwl/po1hN3azTyixKnr8ReEqUv5WK7WsO+5AWB0bFndML5Yqnt8ARZ90HEg8/P6WlqE/AB2413TkCRZE8bA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0.tgz",
+      "integrity": "sha512-41mf22CImjwNdtOG3r+cdC8+RhwNm616sjHx5YlqTwtSJLyLFinbQC/a4PIFk8xqf1qpFH1kEAIw+yx9HaqZ3g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0.tgz",
+      "integrity": "sha512-Jw+BZ8JIw1f12V0SERqGlBT1JEPWax3vuZpMym54NAXpPb7R1LYHiCTIlaJUyqvIfEy3kiHMtgI+r2whGgRIxQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0.tgz",
+      "integrity": "sha512-qslqvL0MUbWuzXJWdUxpj6mdNUX8jr4FFTo3aZnAT65nmzWL7g8oTr9ZxmTXXgdp7ANhS1QWE7036/Q2isFBpw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.6",
+        "jss": "10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
@@ -12563,6 +13131,31 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
@@ -12925,6 +13518,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
+    "normalize-scroll-left": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
+      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
     },
     "normalize-url": {
       "version": "3.3.0",
@@ -13552,6 +14150,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.1.0.tgz",
       "integrity": "sha512-CPCdcFxx7fEcDMWTDjXe2Wypt4JuMt4q5Q2UrpTcyBBkLiCIyPEh/mCGmUWIcNkKGyXwQ9Y2wVhlKm6ketiBNQ=="
+    },
+    "popper.js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     },
     "portfinder": {
       "version": "1.0.19",
@@ -15610,25 +16213,13 @@
       "dev": true
     },
     "react": {
-      "version": "16.6.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
-      "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
+      "integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.11.2"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
-          "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "prop-types": "^15.6.2"
       }
     },
     "react-app-polyfill": {
@@ -15800,25 +16391,14 @@
       }
     },
     "react-dom": {
-      "version": "16.6.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
-      "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.10.2.tgz",
+      "integrity": "sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.11.2"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
-          "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "scheduler": "^0.16.2"
       }
     },
     "react-error-overlay": {
@@ -15974,49 +16554,124 @@
       }
     },
     "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
         "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "dependencies": {
-        "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
           "requires": {
-            "loose-envify": "^1.0.0"
+            "regenerator-runtime": "^0.13.2"
           }
+        },
+        "history": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.10.2",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+              "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        },
+        "resolve-pathname": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+          "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
+        },
+        "value-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+          "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         }
       }
     },
     "react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
         "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-router": "5.1.2",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "dependencies": {
-        "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
           "requires": {
-            "loose-envify": "^1.0.0"
+            "regenerator-runtime": "^0.13.2"
           }
+        },
+        "history": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        },
+        "resolve-pathname": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+          "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
+        },
+        "value-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+          "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         }
       }
     },
@@ -17451,6 +18106,15 @@
       "integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
       "requires": {
         "xmlchars": "^1.3.1"
+      }
+    },
+    "scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "schema-utils": {
@@ -19356,6 +20020,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -19968,6 +20642,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-force-update": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/use-force-update/-/use-force-update-1.0.7.tgz",
+      "integrity": "sha512-k5dppYhO+I5X/cd7ildbrzeMZJkWwdAh5adaIk0qKN2euh7J0h2GBGBcB4QZ385eyHHnp7LIygvebdRx3XKdwA=="
+    },
+    "use-react-router": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/use-react-router/-/use-react-router-1.0.7.tgz",
+      "integrity": "sha512-gdqIHEO28E+qDJQ+tOMGQPthPib7mhLI/4MY7wtxJuaVUkosbP+FAYcHmmE7/FjYoMsuzL/bvY/25st7QHodpw==",
+      "requires": {
+        "use-force-update": "^1.0.5"
+      }
     },
     "useragent": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16502,7 +16502,7 @@
     },
     "react-redux": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
       "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
       "requires": {
         "@babel/runtime": "^7.1.2",
@@ -16515,30 +16515,32 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "^0.13.2"
           }
         },
         "hoist-non-react-statics": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
-          "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
           "requires": {
-            "react-is": "^16.3.2"
+            "react-is": "^16.7.0"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.10.2",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+              "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+            }
           }
         },
-        "react-is": {
-          "version": "16.6.3",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-          "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
-        },
         "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -17310,9 +17312,9 @@
       }
     },
     "redux": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
-      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-tooltip": "3.8.0",
     "react-transition-group": "^2.5.0",
     "recharts": "^1.4.1",
-    "redux": "^4.0.1",
+    "redux": "^4.0.4",
     "redux-responsive": "^4.3.8",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "http://github.com/odota/web"
   },
   "dependencies": {
+    "@material-ui/core": "^4.5.0",
+    "@material-ui/icons": "^4.4.3",
+    "@material-ui/styles": "^4.5.0",
     "abcolor": "^0.5.5",
     "ace-builds": "^1.4.2",
     "core-js": "^2.5.7",
@@ -39,14 +42,14 @@
     "nanoid": "^2.0.1",
     "papaparse": "^4.6.2",
     "prop-types": "^15.6.2",
-    "react": "^16.6.3",
+    "react": "^16.10.2",
     "react-content-loader": "^3.1.2",
-    "react-dom": "^16.6.3",
+    "react-dom": "^16.10.2",
     "react-ga": "^2.5.5",
     "react-helmet": "^5.2.0",
     "react-markdown": "^4.0.3",
     "react-redux": "^5.1.1",
-    "react-router-dom": "^4.3.1",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "^2.1.1",
     "react-stripe-checkout": "^2.6.3",
     "react-tooltip": "3.8.0",
@@ -58,6 +61,7 @@
     "reselect": "^4.0.0",
     "seamless-immutable": "^7.1.3",
     "styled-components": "^4.1.1",
+    "use-react-router": "^1.0.7",
     "wordcloud": "^1.1.0"
   },
   "devDependencies": {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -5,7 +5,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Helmet from 'react-helmet';
-import { Route, Switch, Link } from 'react-router-dom';
+import { Route, Switch, withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 import Header from '../Header';
 import Player from '../Player';
@@ -144,29 +144,62 @@ class App extends React.Component {
 
   render() {
     const {
-      width, location, strings,
+      width, strings, location,
     } = this.props;
 
     const navbarPages = [
-      <Link key="header_explorer" to="/explorer">{strings.header_explorer}</Link>,
-      <Link key="header_combos" to="/combos">{strings.combos}</Link>,
-      <Link key="header_meta" to="/meta">{strings.header_meta}</Link>,
-      <Link key="header_matches" to="/matches">{strings.header_matches}</Link>,
-      <Link key="header_teams" to="/teams">{strings.header_teams}</Link>,
-      <Link key="header_heroes" to="/heroes">{strings.header_heroes}</Link>,
-      <Link key="header_distributions" to="/distributions">{strings.header_distributions}</Link>,
-      <Link key="header_records" to="/records">{strings.header_records}</Link>,
-      <Link key="header_scenarios" to="/scenarios">{strings.header_scenarios}</Link>,
-      <Link key="header_api" to="/api-keys">{strings.header_api}</Link>,
-      // <Link key="header_predictions" to="/predictions">TI Predictions</Link>,
-      // <Link key="header_assistant" to="/assistant">Assistant</Link>,
+      {
+        key: 'header_matches',
+        to: '/matches',
+        label: strings.header_matches,
+      },
+      {
+        key: 'header_heroes',
+        to: '/heroes',
+        label: strings.header_heroes,
+      },
+      {
+        key: 'header_teams',
+        to: '/combos',
+        label: strings.combos,
+      },
+      {
+        key: 'header_meta',
+        to: '/meta',
+        label: strings.header_meta,
+      },
+      {
+        key: 'header_explorer',
+        to: '/explorer',
+        label: strings.header_explorer,
+      },
+      {
+        key: 'header_distributions',
+        to: '/distributions',
+        label: strings.header_distributions,
+      },
+      {
+        key: 'header_records',
+        to: '/records',
+        label: strings.header_records,
+      },
+      {
+        key: 'header_scenarios',
+        to: '/scenarios',
+        label: strings.header_scenarios,
+      },
+      {
+        key: 'header_api',
+        to: '/api-keys',
+        label: strings.header_api,
+      },
     ];
 
     const includeAds = !['/', '/api-keys'].includes(location.pathname);
     return (
       <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
         <GlobalStyle />
-        <StyledDiv {...this.props}>
+        <StyledDiv {...this.props} location={location}>
           <Helmet
             defaultTitle={strings.title_default}
             titleTemplate={strings.title_template}
@@ -227,4 +260,4 @@ const mapStateToProps = state => ({
   strings: state.app.strings,
 });
 
-export default connect(mapStateToProps)(App);
+export default connect(mapStateToProps)(withRouter(App));

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -5,15 +5,12 @@ import { Link } from 'react-router-dom';
 import useReactRouter from 'use-react-router';
 import ActionSearch from 'material-ui/svg-icons/action/search';
 import IconButton from '@material-ui/core/IconButton';
-import MoreVert from '@material-ui/icons/MoreVert';
+import { MoreVert, Settings, BugReport } from '@material-ui/icons';
 import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
-import ActionSettings from 'material-ui/svg-icons/action/settings';
-import Bug from 'material-ui/svg-icons/action/bug-report';
 import LogOutButton from 'material-ui/svg-icons/action/power-settings-new';
 import { Menu, MenuItem } from '@material-ui/core';
 import styled from 'styled-components';
 import LocalizationMenu from '../Localization';
-import Dropdown from '../Header/Dropdown';
 import constants from '../constants';
 import AccountWidget from '../AccountWidget';
 import SearchForm from '../Search/SearchForm';
@@ -24,12 +21,6 @@ import { GITHUB_REPO } from '../../config';
 const REPORT_BUG_PATH = `//github.com/${GITHUB_REPO}/issues`;
 
 const VerticalAlignToolbar = styled(ToolbarGroup)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const VerticalAlignDropdown = styled(Dropdown)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -130,6 +121,24 @@ LinkGroup.propTypes = {
   navbarPages: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
+const SettingsGroup = ({ children }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const handleClose = useCallback(() => {
+    setAnchorEl(undefined);
+  }, [anchorEl]);
+
+  return (
+    <>
+      <IconButton color="inherit" onClick={e => setAnchorEl(e.currentTarget)}>
+        <Settings />
+      </IconButton>
+      <DropdownMenu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose} PaperProps={{ style: { maxHeight: 600 } }}>
+        {children}
+      </DropdownMenu>
+    </>
+  );
+};
+
 class Header extends React.Component {
   static propTypes = {
     location: PropTypes.shape({}),
@@ -157,10 +166,6 @@ class Header extends React.Component {
 
     navbarPages.forEach(page => burgerItems.push(<Link key={page.key} to={page.to}>{page.label}</Link>));
 
-    const buttonProps = {
-      children: <ActionSettings />,
-    };
-
     const LogoGroup = ({ small }) => (
       <VerticalAlignToolbar>
         {!small && <BurgerMenu menuItems={burgerItems} />}
@@ -185,32 +190,11 @@ class Header extends React.Component {
       </VerticalAlignToolbar>
     );
 
-    const SettingsGroup = ({ user }) => (
-      <VerticalAlignDropdown
-        Button={IconButton}
-        buttonProps={buttonProps}
-      >
-        <LocalizationMenu />
-        <ReportBug />
-        {user ? <LogOut /> : null}
-      </VerticalAlignDropdown>
-    );
-
-    SettingsGroup.propTypes = {
-      user: PropTypes.shape({}),
-    };
-
     const ReportBug = () => (
-      <BugLink
-        href={REPORT_BUG_PATH}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Bug />
-        <span>
-          {strings.app_report_bug}
-        </span>
-      </BugLink>
+      <DropdownMenuItem component="a" href={REPORT_BUG_PATH} target="_blank" rel="noopener noreferrer" >
+        <BugReport style={{ marginRight: 32, width: 24, height: 24 }} />
+        {strings.app_report_bug}
+      </DropdownMenuItem>
     );
 
     const LogOut = () => (
@@ -237,7 +221,11 @@ class Header extends React.Component {
           {!disableSearch && <SearchGroup />}
           <VerticalAlignDiv style={{ marginLeft: '16px' }}>
             {small && <AccountGroup />}
-            {<SettingsGroup user={user} />}
+            <SettingsGroup>
+              <LocalizationMenu />
+              <ReportBug />
+              {user ? <LogOut /> : null}
+            </SettingsGroup>
           </VerticalAlignDiv>
         </ToolbarHeader>
         { location.pathname !== '/' && Announce && <Announce /> }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -235,7 +235,7 @@ class Header extends React.Component {
             {small && <LinkGroup navbarPages={navbarPages} />}
           </VerticalAlignDiv>
           {!disableSearch && <SearchGroup />}
-          <VerticalAlignDiv style={{ marginLeft: 'auto' }}>
+          <VerticalAlignDiv style={{ marginLeft: '16px' }}>
             {small && <AccountGroup />}
             {<SettingsGroup user={user} />}
           </VerticalAlignDiv>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import useReactRouter from 'use-react-router';
 import ActionSearch from 'material-ui/svg-icons/action/search';
+import IconButton from '@material-ui/core/IconButton';
+import MoreVert from '@material-ui/icons/MoreVert';
 import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
-import IconButton from 'material-ui/IconButton';
 import ActionSettings from 'material-ui/svg-icons/action/settings';
 import Bug from 'material-ui/svg-icons/action/bug-report';
 import LogOutButton from 'material-ui/svg-icons/action/power-settings-new';
+import { Menu, MenuItem } from '@material-ui/core';
 import styled from 'styled-components';
 import LocalizationMenu from '../Localization';
 import Dropdown from '../Header/Dropdown';
@@ -38,10 +42,13 @@ const VerticalAlignDiv = styled.div`
 `;
 
 const TabContainer = styled.div`
-  height: 100%;
   display: flex;
   flex-direction: column;
+  font-weight: ${constants.fontWeightNormal};
+  height: 100%;
   justify-content: center;
+  margin: 0 10px;
+  text-align: center;
 `;
 
 const BugLink = styled.a`
@@ -61,6 +68,16 @@ const BugLink = styled.a`
   }
 `;
 
+const DropdownMenu = styled(Menu)`
+  & .MuiMenu-paper {
+    background: ${constants.primarySurfaceColor};
+  }
+`;
+
+const DropdownMenuItem = styled(MenuItem)`
+  color: ${constants.primaryTextColor} !important;
+`;
+
 const ToolbarHeader = styled(Toolbar)`
   background-color: ${constants.defaultPrimaryColor} !important;
   padding: 8px !important;
@@ -72,6 +89,46 @@ const ToolbarHeader = styled(Toolbar)`
     }
   }
 `;
+
+const LinkGroup = ({ navbarPages }) => {
+  const router = useReactRouter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const handleClose = useCallback(() => {
+    setAnchorEl(undefined);
+  }, [anchorEl]);
+
+  return (
+    <VerticalAlignToolbar>
+      {navbarPages.slice(0, 6).map(page => (
+        <TabContainer key={page.key}>
+          <Link to={page.to}>{page.label}</Link>
+        </TabContainer>
+      ))}
+      <TabContainer>
+        <IconButton size="small" color="inherit" onClick={e => setAnchorEl(e.currentTarget)}>
+          <MoreVert />
+        </IconButton>
+        <DropdownMenu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+          {navbarPages.slice(6, navbarPages.length).map(page => (
+            <DropdownMenuItem
+              onClick={() => {
+                router.history.push(page.to);
+                handleClose();
+              }}
+              key={page.key}
+            >
+              {page.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenu>
+      </TabContainer>
+    </VerticalAlignToolbar>
+  );
+};
+
+LinkGroup.propTypes = {
+  navbarPages: PropTypes.arrayOf(PropTypes.shape({})),
+};
 
 class Header extends React.Component {
   static propTypes = {
@@ -96,8 +153,9 @@ class Header extends React.Component {
 
     const burgerItems = [
       <AccountWidget key={0} />,
-      ...navbarPages,
     ];
+
+    navbarPages.forEach(page => burgerItems.push(<Link key={page.key} to={page.to}>{page.label}</Link>));
 
     const buttonProps = {
       children: <ActionSettings />,
@@ -114,20 +172,8 @@ class Header extends React.Component {
       small: PropTypes.bool,
     };
 
-    const LinkGroup = () => (
-      <VerticalAlignToolbar>
-        {navbarPages.map(Page => (
-          <TabContainer key={Page.key}>
-            <div style={{ margin: '0 10px', textAlign: 'center', fontWeight: `${constants.fontWeightNormal} !important` }}>
-              {Page}
-            </div>
-          </TabContainer>
-      ))}
-      </VerticalAlignToolbar>
-    );
-
     const SearchGroup = () => (
-      <VerticalAlignToolbar style={{ marginLeft: 20 }}>
+      <VerticalAlignToolbar style={{ marginLeft: 'auto' }}>
         <ActionSearch style={{ marginRight: 6, opacity: '.6' }} />
         <SearchForm />
       </VerticalAlignToolbar>
@@ -186,9 +232,9 @@ class Header extends React.Component {
         <ToolbarHeader>
           <VerticalAlignDiv>
             <LogoGroup small={small} />
-            {small && <LinkGroup />}
-            {!disableSearch && <SearchGroup />}
+            {small && <LinkGroup navbarPages={navbarPages} />}
           </VerticalAlignDiv>
+          {!disableSearch && <SearchGroup />}
           <VerticalAlignDiv style={{ marginLeft: 'auto' }}>
             {small && <AccountGroup />}
             {<SettingsGroup user={user} />}

--- a/src/components/Localization/index.jsx
+++ b/src/components/Localization/index.jsx
@@ -1,27 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import MenuItem from 'material-ui/MenuItem';
-import Next from 'material-ui/svg-icons/hardware/keyboard-arrow-right';
+import { List, ListItem, ListItemIcon, ListItemText, Collapse } from '@material-ui/core';
+import { ExpandMore, ExpandLess, Translate } from '@material-ui/icons';
 import styled from 'styled-components';
 import { langs } from '../../lang/index';
 import constants from '../constants';
 
-const ClickableDiv = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  transition: ${constants.linearTransition};
-  padding-right: 10px;
+const StyledListItem = styled(ListItem)`
+  color: ${constants.primaryTextColor} !important;
 `;
 
-const LanguageContainerDiv = styled.div`
-  max-height: 300px;
-  overflow: auto;
+const StyledListItemIcon = styled(ListItemIcon)`
+  color: ${constants.primaryTextColor} !important;
 `;
-
-const getLocalization = window.localStorage.getItem('localization');
 
 const setLocalization = (event, key, payload) => {
   window.localStorage.setItem('localization', payload.value);
@@ -49,22 +41,24 @@ class LocalizationMenuItems extends Component {
     const { open } = this.state;
     return (
       <div style={{ minWidth: '200px' }}>
-        <ClickableDiv
-          onClick={this.handleOnClick}
-        >
-          {strings.app_language} <Next />
-        </ClickableDiv>
-        <LanguageContainerDiv>
-          {open && langs.map(lang => (<MenuItem
-            style={{
-              color: lang.value === getLocalization && constants.colorGolden,
-            }}
-            key={lang.translated}
-            value={lang.value}
-            primaryText={lang.native}
-            onClick={() => setLocalization(null, null, lang)}
-          />))}
-        </LanguageContainerDiv>
+        <List component="div">
+          <StyledListItem button onClick={this.handleOnClick}>
+            <StyledListItemIcon>
+              <Translate />
+            </StyledListItemIcon>
+            <ListItemText primary={strings.app_language} />
+            {open ? <ExpandLess /> : <ExpandMore />}
+          </StyledListItem>
+          <Collapse in={open} timeout="auto" unmountOnExit style={{ maxHeight: 300, overflow: 'auto' }}>
+            <List component="div" disablePadding>
+              {langs.map(lang => (
+                <StyledListItem button onClick={() => setLocalization(null, null, lang)} key={lang.translated}>
+                  <ListItemText primary={lang.native} />
+                </StyledListItem>
+              ))}
+            </List>
+          </Collapse>
+        </List>
       </div>
     );
   }

--- a/src/components/Search/SearchForm.jsx
+++ b/src/components/Search/SearchForm.jsx
@@ -61,7 +61,7 @@ class SearchForm extends React.Component {
   render() {
     const { strings, small } = this.props;
     return (
-      <form onSubmit={this.formSubmit} style={{ width: small ? '280px' : '350px' }}>
+      <form onSubmit={this.formSubmit} style={{ width: small ? '280px' : 'auto' }}>
         <TextField
           id="searchField"
           hintText={strings.search_title}

--- a/src/components/Search/SearchForm.jsx
+++ b/src/components/Search/SearchForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import debounce from 'lodash/fp/debounce';
+import debounce from 'lodash/debounce';
 import TextField from 'material-ui/TextField';
 import querystring from 'querystring';
 import { getSearchResultAndPros, setSearchQuery } from '../../actions';
@@ -61,7 +61,7 @@ class SearchForm extends React.Component {
   render() {
     const { strings, small } = this.props;
     return (
-      <form onSubmit={this.formSubmit}>
+      <form onSubmit={this.formSubmit} style={{ width: small ? '280px' : '350px' }}>
         <TextField
           id="searchField"
           hintText={strings.search_title}
@@ -74,7 +74,7 @@ class SearchForm extends React.Component {
             left: '-40px',
             width: 'calc(100% + 40px)',
           }}
-          style={{ width: small ? '150%' : '100%', whiteSpace: 'nowrap', overflow: 'hidden' }}
+          style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
           underlineStyle={{ borderColor: 'transparent' }}
         />
       </form>

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import createHistory from 'history/createBrowserHistory';
-import { hydrate, render } from 'react-dom';
+import { render, hydrate } from 'react-dom';
 import { Provider } from 'react-redux';
-import { Route, Router } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import store from './store';
 import { getMetadata, getStrings, getAbilities, getHeroAbilities, getNeutralAbilities, getAbilityIds } from './actions';
 import App from './components/App';
@@ -31,13 +31,16 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 const rootElement = document.getElementById('root');
+
 const app = (
   <Provider store={store}>
-    <Router history={history}>
-      <Route component={App} />
-    </Router>
+    <BrowserRouter history={history}>
+      <App />
+    </BrowserRouter>
   </Provider>
 );
+
+render(app, rootElement);
 
 if (rootElement.hasChildNodes()) {
   render(app, rootElement);

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,6 @@ const app = (
   </Provider>
 );
 
-render(app, rootElement);
-
 if (rootElement.hasChildNodes()) {
   render(app, rootElement);
 } else {


### PR DESCRIPTION
closes #2214 

With this PR I'm starting to rebuild the navigation/headerbar component and introduced some package updates so we can move onwards with functionalities and get around dirty ways like using a Route for the app to have access to the router.

Updated packages:
- React => 16.10.2
- ReactDOM => 16.10.2
- ReactRouterDOM => 5.1.2

I also started implement @material-ui/core since the old material-core npm package was deprecated a long time ago so we should start to reimplement components with the new library from now on + rewrite old components. What do you think about this @howardchung ?

I also implemented the `use-react-router` hook to get direct router access from any functional component.

Screenshots:

Menu default:
![image](https://user-images.githubusercontent.com/6538827/66276399-f08aac80-e892-11e9-8e4f-b67b0d729366.png)

Menu open:
![image](https://user-images.githubusercontent.com/6538827/66276404-fbddd800-e892-11e9-88dd-fca4723bab34.png)
