### PR TITLE
Refactor TabbedContent Component

### DIFF
--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
+import useReactRouter from 'use-react-router';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
-import ReactTooltip from 'react-tooltip';
+import { Tab, Tabs } from '@material-ui/core';
 import constants from '../constants';
 
 const StyledMain = styled.main`
@@ -10,77 +10,58 @@ const StyledMain = styled.main`
   margin: 10px 0 30px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.19);
 `;
-const StyledSection = styled.section`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  flex-wrap: wrap;
 
-  & a {
-    /* Tab */
-    text-align: center;
-    font-size: 13px;
-    color: ${constants.primaryTextColor};
-    padding: 10px 8px 16px;
-    border-bottom: 2px solid transparent;
-    flex-grow: 1;
-    transition: none;
-
-    &:hover {
-      color: ${constants.colorMutedLight};
-    }
-
-    &[disabled] {
-      pointer-events: none;
-      color: ${constants.colorMuted};
-    }
-
-    &[hidden] {
-      display: none;
-    }
-
-    @media only screen and (max-width: 768px) {
-      padding-left: 10px;
-      padding-right: 10px;
-    }
-  }
-
-  & .chosen {
-    display: inline-block;
-    border-color: ${constants.primaryLinkColor};
-    color: color(${constants.colorMuted} lightness(85%));
+const StyledTabs = styled(Tabs)`
+  & .MuiTabs-indicator {
+    background: ${constants.primaryLinkColor};
   }
 `;
 
-const TabBar = ({ tabs, info, match }) => (
-  <StyledMain>
-    <StyledSection>
-      {tabs.map(tab => (
-        <Link
-          key={`${tab.name}_${tab.route}_${tab.key}`}
-          className={tab.key === info ? 'chosen' : ''}
-          to={tab.route + window.location.search}
-          disabled={tab.disabled}
-          hidden={tab.hidden && tab.hidden(match)}
-        >
-          <div data-tip={tab.tooltip} data-for={`tooltip_${tab.key}`}>
-            {tab.name}
-            {tab.tooltip &&
-            <ReactTooltip id={`tooltip_${tab.key}`} place="top" effect="solid">
-              {tab.tooltip}
-            </ReactTooltip>
-            }
-          </div>
-        </Link>
-      ))}
-    </StyledSection>
-  </StyledMain>
-);
+const StyledTab = styled(Tab)`
+  min-width: 0 !important;
+`;
 
-const { string, shape, arrayOf } = PropTypes;
+const TabBar = ({ tabs, match }) => {
+  const [tabValue, setTabValue] = useState(0);
+  const { history, location } = useReactRouter();
+
+  useEffect(() => {
+    tabs.forEach((tab, i) => {
+      if (location.pathname === tab.route) setTabValue(i);
+    });
+  }, []);
+
+  const handleTabClick = useCallback((e) => {
+    e.preventDefault();
+    history.push(e.currentTarget.getAttribute('href'));
+  }, [history]);
+
+  return (
+    <StyledMain>
+      <StyledTabs
+        value={tabValue}
+        onChange={(e, newValue) => setTabValue(newValue)}
+        variant="scrollable"
+        indicatorColor="primary"
+      >
+        {tabs.map(tab => (!tab.hidden || (tab.hidden && !tab.hidden(match))) && (
+          <StyledTab
+            component="a"
+            key={`${tab.name}_${tab.route}_${tab.key}`}
+            href={tab.route + window.location.search}
+            onClick={handleTabClick}
+            label={tab.name}
+            disabled={tab.disabled}
+          />
+        ))}
+      </StyledTabs>
+    </StyledMain>
+  );
+};
+
+const { shape, arrayOf } = PropTypes;
 TabBar.propTypes = {
   tabs: arrayOf(shape({})),
-  info: string,
   match: shape({}),
 };
 


### PR DESCRIPTION
This PR will refactor the TabbedContent component. It includes the new `<Tabs />` and `<Tab />` component from `@material-core/ui`.

This fixes the way to large tabs for TabbedContent views.

# Matches

Before:
![image](https://user-images.githubusercontent.com/6538827/66291678-bc3edc80-e8e2-11e9-8605-ecd36ce14a14.png)

After:
![image](https://user-images.githubusercontent.com/6538827/66291735-dbd60500-e8e2-11e9-975f-80a4c29a441b.png)


# Match View

Before:
![image](https://user-images.githubusercontent.com/6538827/66291807-02943b80-e8e3-11e9-985c-2b105fab3a3a.png)

After:
![image](https://user-images.githubusercontent.com/6538827/66291822-09bb4980-e8e3-11e9-8603-6a3bd86c8f45.png)
