### PR TITLE
refactored navbar styling and logo spacings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16501,17 +16501,16 @@
       }
     },
     "react-redux": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.1.tgz",
+      "integrity": "sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.1.0",
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -16528,14 +16527,22 @@
           "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
           "requires": {
             "react-is": "^16.7.0"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.10.2",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-              "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
-            }
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "regenerator-runtime": {
           "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-ga": "^2.5.5",
     "react-helmet": "^5.2.0",
     "react-markdown": "^4.0.3",
-    "react-redux": "^5.1.1",
+    "react-redux": "^7.1.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^2.1.1",
     "react-stripe-checkout": "^2.6.3",

--- a/src/components/AccountWidget/AccountWidget.jsx
+++ b/src/components/AccountWidget/AccountWidget.jsx
@@ -2,48 +2,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
+import { Button } from '@material-ui/core';
 import { IconSteam } from '../Icons';
-import Spinner from '../Spinner';
 import Error from '../Error';
 import LoggedIn from './LoggedIn';
 
-const IconButtonLink = styled.a`
-  padding: 0 !important;
-  height: auto !important;
-  width: auto !important;
-
-  & svg:hover {
-    opacity: 1;
-  }
-
-  &[data-hint-position="bottom"] {
-    &::before {
-      bottom: -9px;
-      left: 8px;
-    }
-
-    &::after {
-      margin-top: 9px;
-    }
-  }
+const ButtonLabel = styled.span`
+  margin-left: 4px;
 `;
 
 const AccountWidget = ({
   loading, error, user, style, strings,
-}) => (
-  <div style={style}>
-    {loading && !error && <Spinner />}
-    {error && <Error />}
-    {!error && !loading && user
-      ? <LoggedIn style={style} playerId={user.account_id} />
-      :
-      <IconButtonLink href={`${process.env.REACT_APP_API_HOST}/login`}>
-        <IconSteam />
-        {strings.app_login}
-      </IconButtonLink>
-    }
-  </div>
-);
+}) => {
+  if (loading) return null;
+  return (
+    <div style={style}>
+      {error && <Error />}
+      {!error && !loading && user
+        ? <LoggedIn style={style} playerId={user.account_id} />
+        :
+        <Button href={`${process.env.REACT_APP_API_HOST}/login`}>
+          <IconSteam />
+          <ButtonLabel>{strings.app_login}</ButtonLabel>
+        </Button>
+      }
+    </div>
+  );
+};
 
 AccountWidget.propTypes = {
   loading: PropTypes.bool,

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -162,13 +162,28 @@ class App extends React.Component {
       },
       {
         key: 'header_teams',
-        to: '/combos',
-        label: strings.combos,
+        to: '/teams',
+        label: strings.header_teams,
+      },
+      {
+        key: 'header_explorer',
+        to: '/explorer',
+        label: strings.header_explorer,
+      },
+      {
+        key: 'header_api',
+        to: '/api-keys',
+        label: strings.header_api,
       },
     ];
 
     const drawerPages = [
       ...navbarPages,
+      {
+        key: 'header_combos',
+        to: '/combos',
+        label: strings.combos,
+      },
       {
         key: 'header_distributions',
         to: '/distributions',
@@ -185,19 +200,9 @@ class App extends React.Component {
         label: strings.header_meta,
       },
       {
-        key: 'header_explorer',
-        to: '/explorer',
-        label: strings.header_explorer,
-      },
-      {
         key: 'header_scenarios',
         to: '/scenarios',
         label: strings.header_scenarios,
-      },
-      {
-        key: 'header_api',
-        to: '/api-keys',
-        label: strings.header_api,
       },
     ];
 

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -203,10 +203,12 @@ class App extends React.Component {
 
     const includeAds = !['/', '/api-keys'].includes(location.pathname);
     return (
-      <navigationContext.Provider value={{
-        navbarPages,
-        drawerPages,
-      }}>
+      <navigationContext.Provider
+        value={{
+          navbarPages,
+          drawerPages,
+        }}
+      >
         <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
           <GlobalStyle />
           <StyledDiv {...this.props} location={location}>

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -26,6 +26,7 @@ import Meta from '../Meta';
 import Api from '../Api';
 import Footer from '../Footer';
 import FourOhFour from '../FourOhFour';
+import navigationContext from '../../context/navigationContext';
 import constants from '../constants';
 import muiTheme from './muiTheme';
 import GlobalStyle from './GlobalStyle';
@@ -38,6 +39,7 @@ const StyledDiv = styled.div`
   flex-direction: column;
   height: 100%;
   left: ${props => (props.open ? '256px' : '0px')};
+  margin-top: ${props => (props.location.pathname === '/' ? '-56px' : '0px')};
   background-image: ${props => (props.location.pathname === '/' ? 'url("/assets/images/home-background.png")' : '')};
   background-position: ${props => (props.location.pathname === '/' ? 'center top' : '')};
   background-repeat: ${props => (props.location.pathname === '/' ? 'no-repeat' : '')};
@@ -163,6 +165,10 @@ class App extends React.Component {
         to: '/combos',
         label: strings.combos,
       },
+    ];
+
+    const drawerPages = [
+      ...navbarPages,
       {
         key: 'header_distributions',
         to: '/distributions',
@@ -197,61 +203,66 @@ class App extends React.Component {
 
     const includeAds = !['/', '/api-keys'].includes(location.pathname);
     return (
-      <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
-        <GlobalStyle />
-        <StyledDiv {...this.props} location={location}>
-          <Helmet
-            defaultTitle={strings.title_default}
-            titleTemplate={strings.title_template}
-          />
-          <Header location={location} navbarPages={navbarPages} />
-          <AdBannerDiv>
-            { includeAds &&
-              <a href="http://www.vpgame.com/?lang=en_us">
-                <img src="/assets/images/vp-banner.jpg" alt="" />
-              </a>
-            }
-          </AdBannerDiv>
-          <StyledBodyDiv {...this.props}>
-            <Switch>
-              <Route exact path="/" component={Home} />
-              <Route exact path="/matches/:matchId?/:info?" component={Matches} />
-              <Route exact path="/players/:playerId/:info?/:subInfo?" component={Player} />
-              <Route exact path="/heroes/:heroId?/:info?" component={Heroes} />
-              <Route exact path="/teams/:teamId?/:info?" component={Teams} />
-              <Route exact path="/distributions/:info?" component={Distributions} />
-              <Route exact path="/request" component={Request} />
-              <Route exact path="/status" component={Status} />
-              <Route exact path="/explorer" component={Explorer} />
-              <Route exact path="/combos" component={Combos} />
-              <Route exact path="/search" component={Search} />
-              <Route exact path="/records/:info?" component={Records} />
-              <Route exact path="/meta" component={Meta} />
-              <Route exact path="/scenarios/:info?" component={Scenarios} />
-              <Route exact path="/predictions" component={Predictions} />
-              <Route exact path="/api-keys" component={Api} />
-              <Route component={FourOhFour} />
-            </Switch>
-          </StyledBodyDiv>
-          <AdBannerDiv>
-            { includeAds &&
-              <div style={{ fontSize: '12px' }}>
-                <a href="https://www.rivalry.com/opendota">
-                  <img src="/assets/images/rivalry-banner.gif" alt="" />
+      <navigationContext.Provider value={{
+        navbarPages,
+        drawerPages,
+      }}>
+        <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
+          <GlobalStyle />
+          <StyledDiv {...this.props} location={location}>
+            <Helmet
+              defaultTitle={strings.title_default}
+              titleTemplate={strings.title_template}
+            />
+            <Header location={location} />
+            <AdBannerDiv>
+              { includeAds &&
+                <a href="http://www.vpgame.com/?lang=en_us">
+                  <img src="/assets/images/vp-banner.jpg" alt="" />
                 </a>
-                <div>
-                  {strings.home_sponsored_by} <a href="https://www.rivalry.com/opendota">Rivalry</a>
+              }
+            </AdBannerDiv>
+            <StyledBodyDiv {...this.props}>
+              <Switch>
+                <Route exact path="/" component={Home} />
+                <Route exact path="/matches/:matchId?/:info?" component={Matches} />
+                <Route exact path="/players/:playerId/:info?/:subInfo?" component={Player} />
+                <Route exact path="/heroes/:heroId?/:info?" component={Heroes} />
+                <Route exact path="/teams/:teamId?/:info?" component={Teams} />
+                <Route exact path="/distributions/:info?" component={Distributions} />
+                <Route exact path="/request" component={Request} />
+                <Route exact path="/status" component={Status} />
+                <Route exact path="/explorer" component={Explorer} />
+                <Route exact path="/combos" component={Combos} />
+                <Route exact path="/search" component={Search} />
+                <Route exact path="/records/:info?" component={Records} />
+                <Route exact path="/meta" component={Meta} />
+                <Route exact path="/scenarios/:info?" component={Scenarios} />
+                <Route exact path="/predictions" component={Predictions} />
+                <Route exact path="/api-keys" component={Api} />
+                <Route component={FourOhFour} />
+              </Switch>
+            </StyledBodyDiv>
+            <AdBannerDiv>
+              { includeAds &&
+                <div style={{ fontSize: '12px' }}>
+                  <a href="https://www.rivalry.com/opendota">
+                    <img src="/assets/images/rivalry-banner.gif" alt="" />
+                  </a>
+                  <div>
+                    {strings.home_sponsored_by} <a href="https://www.rivalry.com/opendota">Rivalry</a>
+                  </div>
                 </div>
-              </div>
-            }
-          </AdBannerDiv>
-          <Footer location={location} width={width} />
-          <button ref={this.setBack2TopRef} id="back2Top" title={strings.back2Top} onClick={this.handleBack2TopClick}>
-            <div>&#9650;</div>
-            <div id="back2TopTxt">{strings.back2Top}</div>
-          </button>
-        </StyledDiv>
-      </MuiThemeProvider>
+              }
+            </AdBannerDiv>
+            <Footer location={location} width={width} />
+            <button ref={this.setBack2TopRef} id="back2Top" title={strings.back2Top} onClick={this.handleBack2TopClick}>
+              <div>&#9650;</div>
+              <div id="back2TopTxt">{strings.back2Top}</div>
+            </button>
+          </StyledDiv>
+        </MuiThemeProvider>
+      </navigationContext.Provider>
     );
   }
 }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -208,61 +208,61 @@ class App extends React.Component {
 
     const includeAds = !['/', '/api-keys'].includes(location.pathname);
     return (
-        <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
-          <GlobalStyle />
-          <StyledDiv {...this.props} location={location}>
-            <Helmet
-              defaultTitle={strings.title_default}
-              titleTemplate={strings.title_template}
-            />
-            <Header location={location} navbarPages={navbarPages} drawerPages={drawerPages} />
-            <AdBannerDiv>
-              { includeAds &&
-                <a href="http://www.vpgame.com/?lang=en_us">
-                  <img src="/assets/images/vp-banner.jpg" alt="" />
+      <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
+        <GlobalStyle />
+        <StyledDiv {...this.props} location={location}>
+          <Helmet
+            defaultTitle={strings.title_default}
+            titleTemplate={strings.title_template}
+          />
+          <Header location={location} navbarPages={navbarPages} drawerPages={drawerPages} />
+          <AdBannerDiv>
+            { includeAds &&
+              <a href="http://www.vpgame.com/?lang=en_us">
+                <img src="/assets/images/vp-banner.jpg" alt="" />
+              </a>
+            }
+          </AdBannerDiv>
+          <StyledBodyDiv {...this.props}>
+            <Switch>
+              <Route exact path="/" component={Home} />
+              <Route exact path="/matches/:matchId?/:info?" component={Matches} />
+              <Route exact path="/players/:playerId/:info?/:subInfo?" component={Player} />
+              <Route exact path="/heroes/:heroId?/:info?" component={Heroes} />
+              <Route exact path="/teams/:teamId?/:info?" component={Teams} />
+              <Route exact path="/distributions/:info?" component={Distributions} />
+              <Route exact path="/request" component={Request} />
+              <Route exact path="/status" component={Status} />
+              <Route exact path="/explorer" component={Explorer} />
+              <Route exact path="/combos" component={Combos} />
+              <Route exact path="/search" component={Search} />
+              <Route exact path="/records/:info?" component={Records} />
+              <Route exact path="/meta" component={Meta} />
+              <Route exact path="/scenarios/:info?" component={Scenarios} />
+              <Route exact path="/predictions" component={Predictions} />
+              <Route exact path="/api-keys" component={Api} />
+              <Route component={FourOhFour} />
+            </Switch>
+          </StyledBodyDiv>
+          <AdBannerDiv>
+            { includeAds &&
+              <div style={{ fontSize: '12px' }}>
+                <a href="https://www.rivalry.com/opendota">
+                  <img src="/assets/images/rivalry-banner.gif" alt="" />
                 </a>
-              }
-            </AdBannerDiv>
-            <StyledBodyDiv {...this.props}>
-              <Switch>
-                <Route exact path="/" component={Home} />
-                <Route exact path="/matches/:matchId?/:info?" component={Matches} />
-                <Route exact path="/players/:playerId/:info?/:subInfo?" component={Player} />
-                <Route exact path="/heroes/:heroId?/:info?" component={Heroes} />
-                <Route exact path="/teams/:teamId?/:info?" component={Teams} />
-                <Route exact path="/distributions/:info?" component={Distributions} />
-                <Route exact path="/request" component={Request} />
-                <Route exact path="/status" component={Status} />
-                <Route exact path="/explorer" component={Explorer} />
-                <Route exact path="/combos" component={Combos} />
-                <Route exact path="/search" component={Search} />
-                <Route exact path="/records/:info?" component={Records} />
-                <Route exact path="/meta" component={Meta} />
-                <Route exact path="/scenarios/:info?" component={Scenarios} />
-                <Route exact path="/predictions" component={Predictions} />
-                <Route exact path="/api-keys" component={Api} />
-                <Route component={FourOhFour} />
-              </Switch>
-            </StyledBodyDiv>
-            <AdBannerDiv>
-              { includeAds &&
-                <div style={{ fontSize: '12px' }}>
-                  <a href="https://www.rivalry.com/opendota">
-                    <img src="/assets/images/rivalry-banner.gif" alt="" />
-                  </a>
-                  <div>
-                    {strings.home_sponsored_by} <a href="https://www.rivalry.com/opendota">Rivalry</a>
-                  </div>
+                <div>
+                  {strings.home_sponsored_by} <a href="https://www.rivalry.com/opendota">Rivalry</a>
                 </div>
-              }
-            </AdBannerDiv>
-            <Footer location={location} width={width} />
-            <button ref={this.setBack2TopRef} id="back2Top" title={strings.back2Top} onClick={this.handleBack2TopClick}>
-              <div>&#9650;</div>
-              <div id="back2TopTxt">{strings.back2Top}</div>
-            </button>
-          </StyledDiv>
-        </MuiThemeProvider>
+              </div>
+            }
+          </AdBannerDiv>
+          <Footer location={location} width={width} />
+          <button ref={this.setBack2TopRef} id="back2Top" title={strings.back2Top} onClick={this.handleBack2TopClick}>
+            <div>&#9650;</div>
+            <div id="back2TopTxt">{strings.back2Top}</div>
+          </button>
+        </StyledDiv>
+      </MuiThemeProvider>
     );
   }
 }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -164,16 +164,6 @@ class App extends React.Component {
         label: strings.combos,
       },
       {
-        key: 'header_meta',
-        to: '/meta',
-        label: strings.header_meta,
-      },
-      {
-        key: 'header_explorer',
-        to: '/explorer',
-        label: strings.header_explorer,
-      },
-      {
         key: 'header_distributions',
         to: '/distributions',
         label: strings.header_distributions,
@@ -182,6 +172,16 @@ class App extends React.Component {
         key: 'header_records',
         to: '/records',
         label: strings.header_records,
+      },
+      {
+        key: 'header_meta',
+        to: '/meta',
+        label: strings.header_meta,
+      },
+      {
+        key: 'header_explorer',
+        to: '/explorer',
+        label: strings.header_explorer,
       },
       {
         key: 'header_scenarios',

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -1,36 +1,36 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Helmet from 'react-helmet';
+import { connect } from 'react-redux';
 import { Route, Switch, withRouter } from 'react-router-dom';
 import styled from 'styled-components';
-import Header from '../Header';
-import Player from '../Player';
-import Home from '../Home';
-import Search from '../Search';
-import Explorer from '../Explorer';
-import Heroes from '../Heroes';
-import Request from '../Request';
-import Distributions from '../Distributions';
-import Status from '../Status';
-import Matches from '../Matches';
-import Teams from '../Teams';
-// import Assistant from '../Assistant';
-import Records from '../Records';
-import Scenarios from '../Scenarios';
-import Predictions from '../Predictions';
-import Meta from '../Meta';
+
+import Combos from './../Combos/Combos';
 import Api from '../Api';
+import constants from '../constants';
+import Distributions from '../Distributions';
+import Explorer from '../Explorer';
 import Footer from '../Footer';
 import FourOhFour from '../FourOhFour';
-import navigationContext from '../../context/navigationContext';
-import constants from '../constants';
-import muiTheme from './muiTheme';
+import Header from '../Header';
+import Heroes from '../Heroes';
+import Home from '../Home';
+import Matches from '../Matches';
+import Meta from '../Meta';
+import Player from '../Player';
+import Predictions from '../Predictions';
+// import Assistant from '../Assistant';
+import Records from '../Records';
+import Request from '../Request';
+import Scenarios from '../Scenarios';
+import Search from '../Search';
+import Status from '../Status';
+import Teams from '../Teams';
 import GlobalStyle from './GlobalStyle';
-import Combos from './../Combos/Combos';
+import muiTheme from './muiTheme';
 
 const StyledDiv = styled.div`
   transition: ${constants.normalTransition};
@@ -208,12 +208,6 @@ class App extends React.Component {
 
     const includeAds = !['/', '/api-keys'].includes(location.pathname);
     return (
-      <navigationContext.Provider
-        value={{
-          navbarPages,
-          drawerPages,
-        }}
-      >
         <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme, muiTheme)}>
           <GlobalStyle />
           <StyledDiv {...this.props} location={location}>
@@ -221,7 +215,7 @@ class App extends React.Component {
               defaultTitle={strings.title_default}
               titleTemplate={strings.title_template}
             />
-            <Header location={location} />
+            <Header location={location} navbarPages={navbarPages} drawerPages={drawerPages} />
             <AdBannerDiv>
               { includeAds &&
                 <a href="http://www.vpgame.com/?lang=en_us">
@@ -269,7 +263,6 @@ class App extends React.Component {
             </button>
           </StyledDiv>
         </MuiThemeProvider>
-      </navigationContext.Provider>
     );
   }
 }

--- a/src/components/App/AppLogo.jsx
+++ b/src/components/App/AppLogo.jsx
@@ -16,8 +16,8 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const AppLogo = ({ size, strings }) => (
-  <StyledLink to="/">
+const AppLogo = ({ size, strings, onClick }) => (
+  <StyledLink to="/" onClick={onClick}>
     <span style={{ fontSize: size }}>
       {`<${strings.app_name}/>`}
     </span>
@@ -27,6 +27,7 @@ const AppLogo = ({ size, strings }) => (
 AppLogo.propTypes = {
   size: PropTypes.string,
   strings: PropTypes.shape({}),
+  onClick: PropTypes.func,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/App/GlobalStyle.jsx
+++ b/src/components/App/GlobalStyle.jsx
@@ -29,13 +29,14 @@ li {
 }
 
 #root {
-  height: 100%;
-  overflow-x: hidden;
-  min-height: 100vh;
   background-color: #192023;
   background-image: -webkit-linear-gradient(315deg, #2e2d45, #1c2127);
   background-image: linear-gradient(135deg, #2e2d45, #1c2127);
   color: ${constants.primaryTextColor};
+  height: 100%;
+  min-height: 100vh;
+  overflow-x: hidden;
+  padding-top: 56px;
 }
 
 [data-tip] {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -165,7 +165,7 @@ const LogoGroup = ({ onMenuClick }) => (
 
 LogoGroup.propTypes = {
   onMenuClick: PropTypes.func,
-}
+};
 
 const SearchGroup = () => (
   <VerticalAlignToolbar style={{ marginLeft: 'auto' }}>
@@ -245,8 +245,8 @@ const Header = ({
           <MenuContent>
             <List>
               <MenuLogoWrapper>
-                <div onClick={() => setMenuState(false)}>
-                  <AppLogo />
+                <div>
+                  <AppLogo onClick={() => setMenuState(false)} />
                 </div>
               </MenuLogoWrapper>
               {navigationState.drawerPages.map(page => (

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,20 +1,20 @@
-import React, { useState, useCallback, useEffect, useContext } from 'react';
+import { IconButton, List, ListItem, ListItemText, Menu, MenuItem, SwipeableDrawer } from '@material-ui/core';
+import { BugReport, Menu as MenuIcon, Settings } from '@material-ui/icons';
+import LogOutButton from 'material-ui/svg-icons/action/power-settings-new';
+import ActionSearch from 'material-ui/svg-icons/action/search';
+import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
 import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import ActionSearch from 'material-ui/svg-icons/action/search';
-import { Menu, MenuItem, IconButton, SwipeableDrawer, List, ListItem, ListItemText } from '@material-ui/core';
-import { Settings, BugReport, Menu as MenuIcon } from '@material-ui/icons';
-import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
-import LogOutButton from 'material-ui/svg-icons/action/power-settings-new';
 import styled from 'styled-components';
-import navigationContext from '../../context/navigationContext';
-import LocalizationMenu from '../Localization';
-import constants from '../constants';
-import AccountWidget from '../AccountWidget';
-import SearchForm from '../Search/SearchForm';
-import AppLogo from '../App/AppLogo';
+
 import { GITHUB_REPO } from '../../config';
+import AccountWidget from '../AccountWidget';
+import AppLogo from '../App/AppLogo';
+import constants from '../constants';
+import LocalizationMenu from '../Localization';
+import SearchForm from '../Search/SearchForm';
 
 const REPORT_BUG_PATH = `//github.com/${GITHUB_REPO}/issues`;
 
@@ -112,18 +112,20 @@ const DrawerLink = styled(Link)`
   color: ${constants.textColorPrimary};
 `;
 
-const LinkGroup = () => {
-  const navigationState = useContext(navigationContext);
-
+const LinkGroup = ({ navbarPages }) => {
   return (
     <VerticalAlignToolbar>
-      {navigationState.navbarPages.map(page => (
+      {navbarPages.map(page => (
         <TabContainer key={page.key}>
           <Link to={page.to}>{page.label}</Link>
         </TabContainer>
       ))}
     </VerticalAlignToolbar>
   );
+};
+
+LinkGroup.propTypes = {
+  navbarPages: PropTypes.shape([{}]),
 };
 
 const SettingsGroup = ({ children }) => {
@@ -208,11 +210,10 @@ LogOut.propTypes = {
 };
 
 const Header = ({
-  location, disableSearch,
+  location, disableSearch, navbarPages, drawerPages,
 }) => {
   const [Announce, setAnnounce] = useState(null);
   const [menuIsOpen, setMenuState] = useState(false);
-  const navigationState = useContext(navigationContext);
   const small = useSelector(state => state.browser.greaterThan.small);
   const user = useSelector(state => state.app.metadata.data.user);
   const strings = useSelector(state => state.app.strings);
@@ -226,7 +227,7 @@ const Header = ({
       <ToolbarHeader>
         <VerticalAlignDiv>
           <LogoGroup onMenuClick={() => setMenuState(true)} />
-          {small && <LinkGroup />}
+          {small && <LinkGroup navbarPages={navbarPages} />}
         </VerticalAlignDiv>
         {!disableSearch && <SearchGroup />}
         <VerticalAlignDiv style={{ marginLeft: '16px' }}>
@@ -249,7 +250,7 @@ const Header = ({
                   <AppLogo onClick={() => setMenuState(false)} />
                 </div>
               </MenuLogoWrapper>
-              {navigationState.drawerPages.map(page => (
+              {drawerPages.map(page => (
                 <DrawerLink key={`drawer__${page.to}`} to={page.to}>
                   <ListItem button key={`drawer__${page.to}`} onClick={() => setMenuState(false)}>
                     <ListItemText primary={page.label} />
@@ -268,6 +269,8 @@ const Header = ({
 Header.propTypes = {
   location: PropTypes.shape({}),
   disableSearch: PropTypes.bool,
+  navbarPages: PropTypes.shape([{}]),
+  drawerPages: PropTypes.shape([{}]),
 };
 
 export default Header;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -112,17 +112,15 @@ const DrawerLink = styled(Link)`
   color: ${constants.textColorPrimary};
 `;
 
-const LinkGroup = ({ navbarPages }) => {
-  return (
-    <VerticalAlignToolbar>
-      {navbarPages.map(page => (
-        <TabContainer key={page.key}>
-          <Link to={page.to}>{page.label}</Link>
-        </TabContainer>
-      ))}
-    </VerticalAlignToolbar>
-  );
-};
+const LinkGroup = ({ navbarPages }) => (
+  <VerticalAlignToolbar>
+    {navbarPages.map(page => (
+      <TabContainer key={page.key}>
+        <Link to={page.to}>{page.label}</Link>
+      </TabContainer>
+    ))}
+  </VerticalAlignToolbar>
+);
 
 LinkGroup.propTypes = {
   navbarPages: PropTypes.shape([{}]),

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -38,7 +38,7 @@ const TabContainer = styled.div`
   font-weight: ${constants.fontWeightNormal};
   height: 100%;
   justify-content: center;
-  margin: 0 10px;
+  margin: 0 12px;
   text-align: center;
 `;
 
@@ -71,7 +71,7 @@ const DropdownMenuItem = styled(MenuItem)`
 
 const ToolbarHeader = styled(Toolbar)`
   background-color: ${constants.defaultPrimaryColor} !important;
-  padding: 8px !important;
+  padding: 8px 16px !important;
   & a {
     color: ${constants.primaryTextColor};
     &:hover {
@@ -88,9 +88,12 @@ const LinkGroup = ({ navbarPages }) => {
     setAnchorEl(undefined);
   }, [anchorEl]);
 
+  const mainNavbarPages = useMemo(() => navbarPages.slice(0, 3), [navbarPages]);
+  const menuNavbarPages = useMemo(() => navbarPages.slice(3, navbarPages.length), [navbarPages]);
+
   return (
     <VerticalAlignToolbar>
-      {navbarPages.slice(0, 6).map(page => (
+      {mainNavbarPages.map(page => (
         <TabContainer key={page.key}>
           <Link to={page.to}>{page.label}</Link>
         </TabContainer>
@@ -100,7 +103,7 @@ const LinkGroup = ({ navbarPages }) => {
           <MoreVert />
         </IconButton>
         <DropdownMenu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
-          {navbarPages.slice(6, navbarPages.length).map(page => (
+          {menuNavbarPages.map(page => (
             <DropdownMenuItem
               onClick={() => {
                 router.history.push(page.to);
@@ -167,10 +170,12 @@ class Header extends React.Component {
     navbarPages.forEach(page => burgerItems.push(<Link key={page.key} to={page.to}>{page.label}</Link>));
 
     const LogoGroup = ({ small }) => (
-      <VerticalAlignToolbar>
-        {!small && <BurgerMenu menuItems={burgerItems} />}
-        <AppLogo style={{ marginRight: 18 }} />
-      </VerticalAlignToolbar>
+      <div style={{ marginRight: 16 }}>
+        <VerticalAlignToolbar>
+          {!small && <BurgerMenu menuItems={burgerItems} />}
+          <AppLogo style={{ marginRight: 18 }} />
+        </VerticalAlignToolbar>
+      </div>
     );
 
     LogoGroup.propTypes = {

--- a/src/components/Match/Laning/Graph.jsx
+++ b/src/components/Match/Laning/Graph.jsx
@@ -1,6 +1,8 @@
+import heroes from 'dotaconstants/build/heroes.json';
+import playerColors from 'dotaconstants/build/player_colors.json';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import {
   Brush,
   CartesianGrid,
@@ -12,12 +14,10 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import heroes from 'dotaconstants/build/heroes.json';
-import playerColors from 'dotaconstants/build/player_colors.json';
-import Heading from '../../Heading';
-import { StyledHolder, StyledCustomizedTooltip } from '../../Visualizations/Graph/Styled';
-import { getHeroIconUrlFromHeroKey } from '../../../utility';
 
+import { getHeroIconUrlFromHeroKey } from '../../../utility';
+import Heading from '../../Heading';
+import { StyledCustomizedTooltip, StyledHolder } from '../../Visualizations/Graph/Styled';
 
 const formatGraphTime = minutes => `${minutes}:00`;
 

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -32,20 +32,19 @@ TabTooltip.propTypes = {
 const TabBar = ({ tabs, match }) => {
   const [tabValue, setTabValue] = useState(0);
   const { history, location } = useReactRouter();
+  const visibleTabs = useMemo(() => tabs.filter(tab => (!tab.hidden || (tab.hidden && !tab.hidden(match)))), [tabs]);
 
   useEffect(() => {
-    tabs.forEach((tab, i) => {
+    visibleTabs.forEach((tab, i) => {
       if (location.pathname === tab.route) setTabValue(i);
     });
-  }, []);
+  }, [visibleTabs]);
 
   const handleTabClick = useCallback((e, tab, index) => {
     e.preventDefault();
     history.push(e.currentTarget.getAttribute('href'));
     setTabValue(index);
   }, [history]);
-
-  const visibleTabs = useMemo(() => tabs.filter(tab => (!tab.hidden || (tab.hidden && !tab.hidden(match)))), [tabs]);
 
   return (
     <StyledMain>

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useState, useEffect } from 'react';
-import useReactRouter from 'use-react-router';
+import { Tab, Tabs, Tooltip } from '@material-ui/core';
 import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { Tooltip, Tab, Tabs } from '@material-ui/core';
+import useReactRouter from 'use-react-router';
+
 import constants from '../constants';
 
 const StyledMain = styled.main`
@@ -44,6 +45,8 @@ const TabBar = ({ tabs, match }) => {
     setTabValue(index);
   }, [history]);
 
+  const visibleTabs = useMemo(() => tabs.filter(tab => (!tab.hidden || (tab.hidden && !tab.hidden(match)))), [tabs]);
+
   return (
     <StyledMain>
       <StyledTabs
@@ -52,7 +55,7 @@ const TabBar = ({ tabs, match }) => {
         variant="scrollable"
         indicatorColor="primary"
       >
-        {tabs.map((tab, i) => (!tab.hidden || (tab.hidden && !tab.hidden(match))) && (
+        {visibleTabs.map((tab, i) => (
           <TabTooltip title={tab.tooltip} key={`${tab.name}_${tab.route}_${tab.key}`}>
             <StyledTab
               component="a"

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,5 +1,6 @@
 export default {
   defaultPrimaryColor: 'rgba(0, 0, 0, 0.4)',
+  defaultPrimaryColorSolid: 'rgba(16, 17, 34, .8)',
   darkPrimaryColor: 'rgba(0, 0, 0, 0.6)',
   almostBlack: 'rgba(0, 0, 0, 0.9)',
   colorSuccess: '#66BB6A',
@@ -83,3 +84,8 @@ export default {
   wrapMobile: '680px',
   appWidth: 1200,
 };
+
+
+export const navbarPages = [
+
+]

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -84,8 +84,3 @@ export default {
   wrapMobile: '680px',
   appWidth: 1200,
 };
-
-
-export const navbarPages = [
-
-]

--- a/src/context/navigationContext.js
+++ b/src/context/navigationContext.js
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const navigationContext = createContext({
+  navbarPages: [],
+  drawerPages: [],
+});
+
+export default navigationContext;

--- a/src/context/navigationContext.js
+++ b/src/context/navigationContext.js
@@ -1,8 +1,0 @@
-import { createContext } from 'react';
-
-const navigationContext = createContext({
-  navbarPages: [],
-  drawerPages: [],
-});
-
-export default navigationContext;


### PR DESCRIPTION
Minor adjustments on the navbar including less menu items (Matches, Heroes, Combos) for more focused navigation and moved all other links to the expand menu.

I also increased the left and right padding of the navbar in total and gave the logo a bit more spacing.

Before:
![image](https://user-images.githubusercontent.com/6538827/66292308-4a679280-e8e4-11e9-8ae0-d9d0158e50b5.png)

After:
![image](https://user-images.githubusercontent.com/6538827/66292323-52273700-e8e4-11e9-903a-bfed8e976ef9.png)
