### PR TITLE
implements new material tooltip

### DIFF
--- a/src/components/Heading/Heading.jsx
+++ b/src/components/Heading/Heading.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -22,9 +23,11 @@ const Heading = ({
       <span className="subtitle">
         {subtitle}
       </span>
-      <span className="info" data-hint={info} style={{ display: info ? 'inline' : 'none' }}>
-        {'(?)'}
-      </span>
+      <Tooltip title={info}>
+        <span className="info" style={{ display: info ? 'inline' : 'none' }}>
+          {'(?)'}
+        </span>
+      </Tooltip>
       {winner &&
       <span className="winner">
         {strings.th_winner}

--- a/src/components/Match/Laning/Graph.jsx
+++ b/src/components/Match/Laning/Graph.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
-  XAxis,
-  YAxis,
-  Tooltip,
-  Line,
   Brush,
-  LineChart,
   CartesianGrid,
   Legend,
+  Line,
+  LineChart,
   ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
 } from 'recharts';
 import heroes from 'dotaconstants/build/heroes.json';
 import playerColors from 'dotaconstants/build/player_colors.json';

--- a/src/components/Match/MatchLog.jsx
+++ b/src/components/Match/MatchLog.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import ReactTooltip from 'react-tooltip';
+import { Tooltip } from '@material-ui/core';
 import heroes from 'dotaconstants/build/heroes.json';
 import {
   formatSeconds,
@@ -194,13 +195,13 @@ const logColumns = (strings) => {
             return (
               <span>
                 <p style={{ float: 'left' }}>{strings.activated}</p>
-                <img
-                  src={`/assets/images/dota2/runes/${runeType}.png`}
-                  alt=""
-                  style={{ height: '30px', float: 'left' }}
-                  data-tip
-                  data-for={runeString}
-                />
+                <Tooltip title={runeString}>
+                  <img
+                    src={`/assets/images/dota2/runes/${runeType}.png`}
+                    alt=""
+                    style={{ height: '30px', float: 'left' }}
+                  />
+                </Tooltip>
                 <p style={{ float: 'left' }}> {runeString} {strings.rune}</p>
               </span>
             );

--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@material-ui/core';
 import heroes from 'dotaconstants/build/heroes.json';
 import items from 'dotaconstants/build/items.json';
 import itemColors from 'dotaconstants/build/item_colors.json';
 import emotes from 'dota2-emoticons/resources/json/charname.json';
-import ReactTooltip from 'react-tooltip';
 import { IconRadiant, IconDire } from '../Icons';
 import {
   formatSeconds,
@@ -63,24 +63,21 @@ const PlayerSpan = (player) => {
   const heroName = heroes[player.hero_id] ? heroes[player.hero_id].localized_name : strings.story_invalid_hero;
   return (
     <span>
-      <StyledStorySpan
-        data-tip
-        data-for={`player_${player.account_id}`}
-        key={`player_${player.player_slot}`}
-        style={{ color: (player.isRadiant ? constants.colorGreen : constants.colorRed) }}
-      >
-        <img
-          src={heroes[player.hero_id]
-            ? process.env.REACT_APP_API_HOST + heroes[player.hero_id].icon
-            : '/assets/images/blank-1x1.gif'
-          }
-          alt=""
-        />
-        {heroName}
-      </StyledStorySpan>
-      <ReactTooltip id={`player_${player.account_id}`} place="left" effect="solid">
-        {player.account_id ? player.personaname : strings.general_anonymous}
-      </ReactTooltip>
+      <Tooltip title={player.account_id ? player.personaname : strings.general_anonymous}>
+        <StyledStorySpan
+          key={`player_${player.player_slot}`}
+          style={{ color: (player.isRadiant ? constants.colorGreen : constants.colorRed) }}
+        >
+          <img
+            src={heroes[player.hero_id]
+              ? process.env.REACT_APP_API_HOST + heroes[player.hero_id].icon
+              : '/assets/images/blank-1x1.gif'
+            }
+            alt=""
+          />
+          {heroName}
+        </StyledStorySpan>
+      </Tooltip>
     </span>);
 };
 

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import findLast from 'lodash/fp/findLast';
+import { Tooltip } from '@material-ui/core';
 import heroes from 'dotaconstants/build/heroes.json';
 import items from 'dotaconstants/build/items.json';
 import orderTypes from 'dotaconstants/build/order_types.json';
@@ -974,12 +975,9 @@ export default (strings) => {
   const runesColumns = [heroTdColumn].concat(Object.keys(strings).filter(str => str.indexOf('rune_') === 0).map(str => str.split('_')[1]).map(runeType => ({
     displayName: (
       <StyledRunes data-tip data-for={`rune_${runeType}`}>
-        <img src={`/assets/images/dota2/runes/${runeType}.png`} alt="" />
-        <ReactTooltip id={`rune_${runeType}`} effect="solid">
-          <span>
-            {strings[`rune_${runeType}`]}
-          </span>
-        </ReactTooltip>
+        <Tooltip title={strings[`rune_${runeType}`]}>
+          <img src={`/assets/images/dota2/runes/${runeType}.png`} alt="" />
+        </Tooltip>
       </StyledRunes>
     ),
     field: `rune_${runeType}`,

--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -470,17 +470,16 @@ export default (strings) => {
     const score = Number(transform(field).toFixed(2));
     const raw = Number((field || 0).toFixed(2));
     return (
-      <div data-tip data-for={`fantasy_${row.player_slot}_${col.field}`}>
-        <span>
-          {score}
-        </span>
-        <small style={{ margin: '3px', color: 'rgb(179, 179, 179)' }}>
-          {raw}
-        </small>
-        <ReactTooltip id={`fantasy_${row.player_slot}_${col.field}`} place="top" effect="solid">
-          {formatTemplateToString(strings.fantasy_description, raw, score)}
-        </ReactTooltip>
-      </div>
+      <Tooltip title={formatTemplateToString(strings.fantasy_description, raw, score)}>
+        <div>
+          <span>
+            {score}
+          </span>
+          <small style={{ margin: '3px', color: 'rgb(179, 179, 179)' }}>
+            {raw}
+          </small>
+        </div>
+      </Tooltip>
     );
   };
 

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
-import ReactTooltip from 'react-tooltip';
 import constants from '../constants';
 
 const StyledMain = styled.main`

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, useEffect } from 'react';
 import useReactRouter from 'use-react-router';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import { Tooltip, Tab, Tabs } from '@material-ui/core';
 import constants from '../constants';
 
@@ -22,9 +21,7 @@ const StyledTab = styled(Tab)`
   min-width: 0 !important;
 `;
 
-const TabTooltip = ({ title, children }) => {
-  return title ? <Tooltip title={title}>{children}</Tooltip> : children;
-};
+const TabTooltip = ({ title, children }) => (title ? <Tooltip title={title}>{children}</Tooltip> : children);
 
 TabTooltip.propTypes = {
   title: PropTypes.string,

--- a/src/components/TabBar/TabBar.jsx
+++ b/src/components/TabBar/TabBar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import ReactTooltip from 'react-tooltip';
 import constants from '../constants';
@@ -52,26 +53,37 @@ const StyledSection = styled.section`
   }
 `;
 
+const TabTooltip = ({ title, children }) => {
+  if (title) {
+    return (
+      <Tooltip title={title}>
+        {children}
+      </Tooltip>
+    );
+  }
+
+  return children;
+};
+
+TabTooltip.propTypes = {
+  title: PropTypes.string,
+};
+
 const TabBar = ({ tabs, info, match }) => (
   <StyledMain>
     <StyledSection>
       {tabs.map(tab => (
-        <Link
-          key={`${tab.name}_${tab.route}_${tab.key}`}
-          className={tab.key === info ? 'chosen' : ''}
-          to={tab.route + window.location.search}
-          disabled={tab.disabled}
-          hidden={tab.hidden && tab.hidden(match)}
-        >
-          <div data-tip={tab.tooltip} data-for={`tooltip_${tab.key}`}>
+        <TabTooltip title={tab.tooltip}>
+          <Link
+            key={`${tab.name}_${tab.route}_${tab.key}`}
+            className={tab.key === info ? 'chosen' : ''}
+            to={tab.route + window.location.search}
+            disabled={tab.disabled}
+            hidden={tab.hidden && tab.hidden(match)}
+          >
             {tab.name}
-            {tab.tooltip &&
-            <ReactTooltip id={`tooltip_${tab.key}`} place="top" effect="solid">
-              {tab.tooltip}
-            </ReactTooltip>
-            }
-          </div>
-        </Link>
+          </Link>
+        </TabTooltip>
       ))}
     </StyledSection>
   </StyledMain>

--- a/src/components/Table/TableHeaderColumn.jsx
+++ b/src/components/Table/TableHeaderColumn.jsx
@@ -1,11 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { Tooltip } from '@material-ui/core';
 import { StyledHeaderCell } from './Styled';
+import { getSortIcon } from './tableHelpers';
 import { getColStyle } from '../../utility';
 
+const HeaderCellContent = styled.div`
+  align-items: center;
+  display: flex;
+  position: relative;
+`;
+
+const HeaderCellSortIconWrapper = styled.div`
+  height: 14px;
+  margin-left: 0px;
+  position: relative;
+  width: 14px;
+`;
+
 const TableHeaderColumn = ({
-  column, sortClick, sortState, index, setHighlightedCol,
+  column, sortClick, sortState, sortField, index, setHighlightedCol,
 }) => {
   const style = {
     justifyContent: column.center ? 'center' : null,
@@ -28,9 +43,16 @@ const TableHeaderColumn = ({
         >
           { !column.tooltip ? column.displayName : (
             <Tooltip title={column.tooltip}>
-              <span>
-                {column.displayName}
-              </span>
+              <HeaderCellContent>
+                <span>
+                  {column.displayName}
+                </span>
+                {column.sortFn && (
+                  <HeaderCellSortIconWrapper>
+                    {getSortIcon(sortState, sortField, column.field, { height: 12, width: 12 })}
+                  </HeaderCellSortIconWrapper>
+                )}
+              </HeaderCellContent>
             </Tooltip>
           ) }
         </div>

--- a/src/components/Table/TableHeaderColumn.jsx
+++ b/src/components/Table/TableHeaderColumn.jsx
@@ -5,6 +5,7 @@ import nanoid from 'nanoid';
 import { getSortIcon } from './tableHelpers';
 import { StyledHeaderCell } from './Styled';
 import { getColStyle } from '../../utility';
+import { Tooltip } from '@material-ui/core';
 
 const TableHeaderColumn = ({
   column, sortClick, sortField, sortState, index, setHighlightedCol,
@@ -27,17 +28,15 @@ const TableHeaderColumn = ({
         style={style}
       >
         <div
-          data-tip={column.tooltip && true}
-          data-for={tooltipId}
           style={{ color: column.color, width: '100%', textAlign: getColStyle(column).textAlign }}
         >
-          {column.displayName}
-          {column.sortFn && getSortIcon(sortState, sortField, column.field, { height: 14, width: 14 })}
-          {column.tooltip &&
-          <ReactTooltip id={tooltipId} place="top" type="light" effect="solid">
-            {column.tooltip}
-          </ReactTooltip>
-          }
+          { !column.tooltip ? column.displayName : (
+            <Tooltip title={column.tooltip}>
+              <span>
+                {column.displayName}
+              </span>
+            </Tooltip>
+          ) }
         </div>
       </StyledHeaderCell>
     </th>

--- a/src/components/Table/TableHeaderColumn.jsx
+++ b/src/components/Table/TableHeaderColumn.jsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactTooltip from 'react-tooltip';
-import nanoid from 'nanoid';
-import { getSortIcon } from './tableHelpers';
+import { Tooltip } from '@material-ui/core';
 import { StyledHeaderCell } from './Styled';
 import { getColStyle } from '../../utility';
-import { Tooltip } from '@material-ui/core';
 
 const TableHeaderColumn = ({
-  column, sortClick, sortField, sortState, index, setHighlightedCol,
+  column, sortClick, sortState, index, setHighlightedCol,
 }) => {
-  const tooltipId = nanoid();
   const style = {
     justifyContent: column.center ? 'center' : null,
   };

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
+import { Tooltip } from '@material-ui/core';
 import ActionDoneAll from 'material-ui/svg-icons/action/done-all';
 import playerColors from 'dotaconstants/build/player_colors.json';
 import SocialPerson from 'material-ui/svg-icons/social/person';
@@ -598,13 +599,11 @@ class TableHeroImage extends React.Component {
                     </span>
                   }
                   {predictedVictory &&
-                    <span
-                      className="hoverIcon"
-                      data-hint={strings.general_predicted_victory}
-                      data-hint-position="top"
-                    >
-                      <IconCrystalBall fill="currentcolor" />
-                    </span>
+                    <Tooltip title={strings.general_predicted_victory}>
+                      <span style={{ marginLeft: '4px' }}>
+                        <IconCrystalBall fill="currentcolor" />
+                      </span>
+                    </Tooltip>
                   }
                 </span>
               </span>


### PR DESCRIPTION
This PR implements the new `@material-ui/core` tooltips for all simple tooltips which don't need special markup or styling and removes several data-tip and ReactTooltip uses.