### PR TITLE
Fix eslint warning about array key in Abilities.jsx

### DIFF
--- a/src/components/Hero/Abilities.jsx
+++ b/src/components/Hero/Abilities.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable object-curly-spacing */
 import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
@@ -33,7 +32,7 @@ const renderAbilities = abilities => abilities.map(ability => (
 const Abilities = ({ hero, abilities, heroAbilities }) => {
   const filterAbilities = toFilterAbs => toFilterAbs.filter(ability => (ability !== 'generic_hidden'));
 
-  const mapAbilities = toFilterAbs => toFilterAbs.map((ability, id) => ({data: abilities[ability], key: id }));
+  const mapAbilities = toFilterAbs => toFilterAbs.map((ability, id) => ({ data: abilities[ability], key: id }));
   const mapTalents = talents => talents.map(talent => ({ ...abilities[talent.name], ...talent }));
 
   const mapTalentsToLevel = (talents) => {

--- a/src/components/Hero/Abilities.jsx
+++ b/src/components/Hero/Abilities.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable object-curly-spacing */
 import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
@@ -23,16 +24,16 @@ const AbilityItem = styled.div`
   padding-right: 4px;
 `;
 
-const renderAbilities = abilities => abilities.map((ability, key) => (
-  <AbilityItem key={key}>
-    <Ability {...ability} abilityID={key} />
+const renderAbilities = abilities => abilities.map(ability => (
+  <AbilityItem key={ability.key}>
+    <Ability {...ability.data} abilityID={ability.key} />
   </AbilityItem>
 ));
 
 const Abilities = ({ hero, abilities, heroAbilities }) => {
   const filterAbilities = toFilterAbs => toFilterAbs.filter(ability => (ability !== 'generic_hidden'));
 
-  const mapAbilities = toFilterAbs => toFilterAbs.map(ability => abilities[ability]);
+  const mapAbilities = toFilterAbs => toFilterAbs.map((ability, id) => ({data: abilities[ability], key: id }));
   const mapTalents = talents => talents.map(talent => ({ ...abilities[talent.name], ...talent }));
 
   const mapTalentsToLevel = (talents) => {


### PR DESCRIPTION
Eslint gives the following warning:

\workspace\Github\web\src\components\Hero\Abilities.jsx
  27:21  warning  Do not use Array index in keys  react/no-array-index-key

Changed 'abilities' to contain 'id' instead of relying on array index, as advised by https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318