### PR TITLE
Add tooltip to Hero Rankings' Score column

### DIFF
--- a/src/components/Player/Pages/Rankings/playerRankingsColumns.jsx
+++ b/src/components/Player/Pages/Rankings/playerRankingsColumns.jsx
@@ -15,6 +15,7 @@ export default strings => [{
   displayFn: displayHeroId,
 }, {
   displayName: strings.th_score,
+  tooltip: strings.tooltip_hero_rankings_score,
   field: 'score',
   sortFn: true,
   relativeBars: true,

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1005,6 +1005,7 @@
   "tooltip_advantage": "Calculated by Wilson score",
   "tooltip_winrate_samplesize": "Win rate and sample size",
   "tooltip_teamfight_participation": "Amount of participation in teamfights",
+  "tooltip_hero_rankings_score": "The score is increased on a win and decreased on a loss. The scored points are based on the average MMR in a match.",
   "histograms_name": "Histograms",
   "histograms_description": "Percentages indicate win rates for the labeled bin",
   "histograms_actions_per_min_description": "Actions performed by player per minute",


### PR DESCRIPTION
In reference to #1342, specifically in [the comment](https://github.com/odota/web/issues/1342#issuecomment-347510522), the `Score` seems confusing so I added a tooltip. 
Not sure if this is the best wording so please let me know if you want to change it. Thanks.