### PR TITLE
Hide contributor label when match table is scrolled

### DIFF
--- a/src/components/Table/Styled.jsx
+++ b/src/components/Table/Styled.jsx
@@ -136,6 +136,10 @@ export const StyledBody = styled.div`
     & .rank {
       display: none !important;
     }
+
+    & .contributor {
+      display: none !important;
+    }
   }
 
   .scrolled .guideContainer {


### PR DESCRIPTION
Fixes https://github.com/odota/web/issues/2231

Scrolling on table on this branch:
![hide-contributor](https://user-images.githubusercontent.com/3903208/67248721-60706980-f433-11e9-8598-529388b0ffba.gif)
