### PR TITLE
Fix bug of incorrect number of casts

### DIFF
--- a/src/components/Match/TargetsBreakdown.jsx
+++ b/src/components/Match/TargetsBreakdown.jsx
@@ -47,7 +47,7 @@ const processCasts = (uses, targets) => {
   const field = {};
   Object.keys(uses).forEach(((ability) => {
     if (targets[ability]) {
-      field[ability] = targets[ability];
+      field[ability] = { ...targets[ability], totalCasts: uses[ability] };
     } else {
       field[ability] = { null: uses[ability] };
     }
@@ -113,11 +113,12 @@ const TargetsBreakdown = ({ field, abilityUses = null }) => {
     }
     const r = [];
     Object.keys(f).forEach((inflictor) => {
+      const valueOverall = f[inflictor].totalCasts ? f[inflictor].totalCasts : sumValues(f[inflictor]);
       r.push((
         <div style={{ display: 'flex' }}>
           {
             <StyledDmgTargetInflictor id="target">
-              {inflictorWithValue(inflictor, abbreviateNumber(sumValues(f[inflictor])))}
+              {inflictorWithValue(inflictor, abbreviateNumber(valueOverall))}
             </StyledDmgTargetInflictor>
           }
           {<NavigationArrowForward style={arrowStyle} />}


### PR DESCRIPTION
This is a fix for issue https://github.com/odota/web/issues/2280

Before:
![image](https://user-images.githubusercontent.com/37062459/68681860-d9fc0300-056c-11ea-9b81-b72a09febcbd.png)

After:
![image](https://user-images.githubusercontent.com/37062459/68681841-cf416e00-056c-11ea-835f-27463ab5ac31.png)

I looked at the 'combat' menu and it looked unchanged (uses the same component)
