### PR TITLE
Added roles to player tables

### DIFF
--- a/src/components/Match/matchColumns.jsx
+++ b/src/components/Match/matchColumns.jsx
@@ -56,6 +56,7 @@ export default (strings) => {
       predictedVictory={row.pred_vict}
       leaverStatus={row.leaver_status}
       hero={compileLevelOneStats(heroes[row.hero_id])}
+      role={row.desc}
     />);
   };
 

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -481,6 +481,7 @@ class TableHeroImage extends React.Component {
       leaverStatus,
       strings,
       hero = {},
+      role,
     } = this.props;
     const { tooltipVisible } = this.state;
 
@@ -576,6 +577,7 @@ class TableHeroImage extends React.Component {
                 </TableLink>
                 : title}
             </span>
+            <span>{role}</span>
             {subtitle &&
               <span style={subTextStyle} className="subTextContainer">
                 {subtitle}
@@ -724,6 +726,7 @@ TableHeroImage.propTypes = {
   strings: shape({}),
   hero: shape({}),
   heroID: number,
+  role: string,
 };
 
 // If need party or estimated, just add new prop with default val = solo and change icons depending what needs


### PR DESCRIPTION
Noticed that we're getting each player's role in the data, so I've added it to the table

![image](https://user-images.githubusercontent.com/37062459/68901336-6c073580-073e-11ea-825f-3903655caeb7.png)

here's how it looks like, might want to add some padding/margin

![image](https://user-images.githubusercontent.com/37062459/68935890-08165880-07a2-11ea-8a6b-742a69f2b158.png)

solves(?) this issue https://github.com/odota/core/issues/1844