### PR TITLE
Add immortal to rank tier, and icons, to heroes page 

### DIFF
--- a/src/components/Heroes/columns.jsx
+++ b/src/components/Heroes/columns.jsx
@@ -18,6 +18,8 @@ export default (strings) => {
     sortFn: row => (heroes[row.hero_id] && heroes[row.hero_id].localized_name),
   };
 
+  const getRankIcon = number => `/assets/images/dota2/rank_icons/rank_icon_${number}.png`;
+
   return {
     pro: [heroColumn, {
       displayName: strings.hero_pick_ban_rate,
@@ -42,96 +44,112 @@ export default (strings) => {
     }],
     public: [heroColumn, {
       displayName: strings.rank_tier_8,
+      displayIcon: getRankIcon(8),
       field: 'pickRate8',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate8, row.matchCount8),
       colColor: constants.colorImmortal,
     }, {
       displayName: strings.rank_tier_8,
+      displayIcon: getRankIcon(8),
       field: 'winRate8',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate8, row['8_pick']),
       colColor: constants.colorImmortalAlt,
     }, {
       displayName: strings.rank_tier_7,
+      displayIcon: getRankIcon(7),
       field: 'pickRate7',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate7, row.matchCount7),
       colColor: constants.colorDivine,
     }, {
       displayName: strings.rank_tier_7,
+      displayIcon: getRankIcon(7),
       field: 'winRate7',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate7, row['7_pick']),
       colColor: constants.colorDivineAlt,
     }, {
       displayName: strings.rank_tier_6,
+      displayIcon: getRankIcon(6),
       field: 'pickRate6',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate6, row.matchCount6),
       colColor: constants.colorAncient,
     }, {
       displayName: strings.rank_tier_6,
+      displayIcon: getRankIcon(6),
       field: 'winRate6',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate6, row['6_pick']),
       colColor: constants.colorAncientAlt,
     }, {
       displayName: strings.rank_tier_5,
+      displayIcon: getRankIcon(5),
       field: 'pickRate5',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate5, row.matchCount5),
       colColor: constants.colorLegend,
     }, {
       displayName: strings.rank_tier_5,
+      displayIcon: getRankIcon(5),
       field: 'winRate5',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate5, row['5_pick']),
       colColor: constants.colorLegendAlt,
     }, {
       displayName: strings.rank_tier_4,
+      displayIcon: getRankIcon(4),
       field: 'pickRate4',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate4, row.matchCount4),
       colColor: constants.colorArchon,
     }, {
       displayName: strings.rank_tier_4,
+      displayIcon: getRankIcon(4),
       field: 'winRate4',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate4, row['4_pick']),
       colColor: constants.colorArchonAlt,
     }, {
       displayName: strings.rank_tier_3,
+      displayIcon: getRankIcon(3),
       field: 'pickRate3',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate3, row.matchCount3),
       colColor: constants.colorCrusader,
     }, {
       displayName: strings.rank_tier_3,
+      displayIcon: getRankIcon(3),
       field: 'winRate3',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate3, row['3_pick']),
       colColor: constants.colorCrusaderAlt,
     }, {
       displayName: strings.rank_tier_2,
+      displayIcon: getRankIcon(2),
       field: 'pickRate2',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate2, row.matchCount2),
       colColor: constants.colorGuardian,
     }, {
       displayName: strings.rank_tier_2,
+      displayIcon: getRankIcon(2),
       field: 'winRate2',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate2, row['2_pick']),
       colColor: constants.colorGuardianAlt,
     }, {
       displayName: strings.rank_tier_1,
+      displayIcon: getRankIcon(1),
       field: 'pickRate1',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.pickRate1, row.matchCount1),
       colColor: constants.colorHerald,
     }, {
       displayName: strings.rank_tier_1,
+      displayIcon: getRankIcon(1),
       field: 'winRate1',
       sortFn: true,
       percentBarsWithValue: row => decimalToCount(row.winRate1, row['1_pick']),

--- a/src/components/Heroes/columns.jsx
+++ b/src/components/Heroes/columns.jsx
@@ -1,9 +1,5 @@
-// import React from 'react';
 import heroes from 'dotaconstants/build/heroes.json';
-import {
-  displayHeroId,
-  abbreviateNumber,
-} from '../../utility';
+import { abbreviateNumber, displayHeroId } from '../../utility';
 import constants from '../constants';
 // import TablePercent from '../Visualizations/Table/Percent';
 
@@ -45,6 +41,18 @@ export default (strings) => {
       percentBarsWithValue: row => decimalToCount(row.winRatePro, row.pro_pick),
     }],
     public: [heroColumn, {
+      displayName: strings.rank_tier_8,
+      field: 'pickRate8',
+      sortFn: true,
+      percentBarsWithValue: row => decimalToCount(row.pickRate8, row.matchCount8),
+      colColor: constants.colorImmortal,
+    }, {
+      displayName: strings.rank_tier_8,
+      field: 'winRate8',
+      sortFn: true,
+      percentBarsWithValue: row => decimalToCount(row.winRate8, row['8_pick']),
+      colColor: constants.colorImmortalAlt,
+    }, {
       displayName: strings.rank_tier_7,
       field: 'pickRate7',
       sortFn: true,

--- a/src/components/Heroes/columns.jsx
+++ b/src/components/Heroes/columns.jsx
@@ -158,6 +158,8 @@ export default (strings) => {
       ...col,
       displayName: i === 0 ? col.displayName : `${(col.displayName || '').substring(0, 2)} ${col.field.startsWith('pick') ? strings.abbr_pick : strings.abbr_win}%`,
       tooltip: col.displayName,
+      paddingLeft: 4,
+      paddingRight: 1,
     })),
   };
 };

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -44,9 +44,9 @@ class RequestLayer extends React.Component {
       ? strings.hero_public_tab
       : strings.hero_pro_tab;
 
-    const title = key === 'pro'
-      ? strings.hero_pro_heading
-      : strings.hero_public_heading;
+    const title = key === 'public'
+      ? strings.hero_public_heading
+      : strings.hero_pro_heading;
 
     return {
       name,

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -56,7 +56,7 @@ class RequestLayer extends React.Component {
     const matchCount3 = json.map(heroStat => heroStat['3_pick'] || 0).reduce(sum, 0) / 10;
     const matchCount2 = json.map(heroStat => heroStat['2_pick'] || 0).reduce(sum, 0) / 10;
     const matchCount1 = json.map(heroStat => heroStat['1_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCountPublic = matchCount7 + matchCount6 + matchCount5 + matchCount4 + matchCount3 + matchCount2 + matchCount1;
+    const matchCountPublic = matchCount8 + matchCount7 + matchCount6 + matchCount5 + matchCount4 + matchCount3 + matchCount2 + matchCount1;
 
     const processedData = json.map((heroStat) => {
       const pickRatePro = (heroStat.pro_pick || 0) / matchCountPro;

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -36,6 +36,27 @@ class RequestLayer extends React.Component {
     this.props.dispatchHeroStats();
     this.props.onGetProPlayers();
   }
+
+  createTab = (key, name, title, matchCount) => {
+    const { strings } = this.props;
+
+    return {
+      name,
+      key,
+      content: (data, _columns, loading) => (
+        <div>
+          <Heading
+            title={title}
+            subtitle={`${abbreviateNumber(matchCount)} ${strings.hero_this_month}`}
+            icon=""
+            twoLine
+          />
+          <Table data={data} columns={_columns} loading={loading} />
+        </div>),
+      route: `/heroes/${key}`,
+    };
+  }
+
   render() {
     const route = this.props.match.params.heroId || 'pro';
 
@@ -97,37 +118,13 @@ class RequestLayer extends React.Component {
       };
     });
     processedData.sort((a, b) => a.heroName && a.heroName.localeCompare(b.heroName));
-    const heroTabs = [{
-      name: strings.hero_pro_tab,
-      key: 'pro',
-      content: (data, _columns, loading) => (
-        <div>
-          <Heading
-            title={strings.hero_pro_heading}
-            subtitle={`${abbreviateNumber(matchCountPro)} ${strings.hero_this_month}`}
-            icon=""
-            twoLine
-          />
-          <Table data={data} columns={_columns} loading={loading} />
-        </div>),
-      route: '/heroes/pro',
-    }, {
-      name: strings.hero_public_tab,
-      key: 'public',
-      content: (data, _columns, loading) => (
-        <div>
-          <Heading
-            title={strings.hero_public_heading}
-            subtitle={`${abbreviateNumber(matchCountPublic)} ${strings.hero_this_month}`}
-            icon=""
-            twoLine
-          />
-          <Table data={data} columns={_columns} loading={loading} />
-        </div>),
-      route: '/heroes/public',
-    }];
 
-    const tab = heroTabs.find(_tab => _tab.key === route);
+    const heroTabs = [
+      this.createTab('pro', strings.hero_pro_tab, strings.hero_pro_heading, matchCountPro),
+      this.createTab('public', strings.hero_public_tab, strings.hero_public_heading, matchCountPublic),
+    ];
+
+    const selectedTab = heroTabs.find(_tab => _tab.key === route);
     const { loading } = this.props;
 
     return (
@@ -138,7 +135,7 @@ class RequestLayer extends React.Component {
             info={route}
             tabs={heroTabs}
           />
-          {tab && tab.content(processedData, columns(strings)[route], loading)}
+          {selectedTab && selectedTab.content(processedData, columns(strings)[route], loading)}
         </div>
       </div>);
   }

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -75,18 +75,17 @@ class RequestLayer extends React.Component {
     }
 
     const json = this.props.data;
-    const { strings } = this.props;
 
     // Assemble the result data array
     const matchCountPro = json.map(heroStat => heroStat.pro_pick || 0).reduce(sum, 0) / 10;
-    const matchCount8 = this.getMatchCountByRank('8_pick');
-    const matchCount7 = this.getMatchCountByRank('7_pick');
-    const matchCount6 = this.getMatchCountByRank('6_pick');
-    const matchCount5 = this.getMatchCountByRank('5_pick');
-    const matchCount4 = this.getMatchCountByRank('4_pick');
-    const matchCount3 = this.getMatchCountByRank('3_pick');
-    const matchCount2 = this.getMatchCountByRank('2_pick');
-    const matchCount1 = this.getMatchCountByRank('1_pick');
+    const matchCount8 = this.getMatchCountByRank(json, '8_pick');
+    const matchCount7 = this.getMatchCountByRank(json, '7_pick');
+    const matchCount6 = this.getMatchCountByRank(json, '6_pick');
+    const matchCount5 = this.getMatchCountByRank(json, '5_pick');
+    const matchCount4 = this.getMatchCountByRank(json, '4_pick');
+    const matchCount3 = this.getMatchCountByRank(json, '3_pick');
+    const matchCount2 = this.getMatchCountByRank(json, '2_pick');
+    const matchCount1 = this.getMatchCountByRank(json, '1_pick');
     const matchCountPublic = matchCount8 + matchCount7 + matchCount6 + matchCount5 + matchCount4 + matchCount3 + matchCount2 + matchCount1;
 
     const processedData = json.map((heroStat) => {
@@ -135,7 +134,7 @@ class RequestLayer extends React.Component {
     ];
 
     const selectedTab = heroTabs.find(_tab => _tab.key === route);
-    const { loading } = this.props;
+    const { loading, strings } = this.props;
 
     return (
       <div>

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -37,8 +37,16 @@ class RequestLayer extends React.Component {
     this.props.onGetProPlayers();
   }
 
-  createTab = (key, name, title, matchCount) => {
+  createTab = (key, matchCount) => {
     const { strings } = this.props;
+
+    const name = key === 'public'
+      ? strings.hero_public_tab
+      : strings.hero_pro_tab;
+
+    const title = key === 'pro'
+      ? strings.hero_pro_heading
+      : strings.hero_public_heading;
 
     return {
       name,
@@ -120,8 +128,8 @@ class RequestLayer extends React.Component {
     processedData.sort((a, b) => a.heroName && a.heroName.localeCompare(b.heroName));
 
     const heroTabs = [
-      this.createTab('pro', strings.hero_pro_tab, strings.hero_pro_heading, matchCountPro),
-      this.createTab('public', strings.hero_public_tab, strings.hero_public_heading, matchCountPublic),
+      this.createTab('pro', matchCountPro),
+      this.createTab('public', matchCountPublic),
     ];
 
     const selectedTab = heroTabs.find(_tab => _tab.key === route);

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -37,6 +37,8 @@ class RequestLayer extends React.Component {
     this.props.onGetProPlayers();
   }
 
+  getMatchCountByRank = (json, rank) => json.map(heroStat => heroStat[rank] || 0).reduce(sum, 0) / 10
+
   createTab = (key, matchCount) => {
     const { strings } = this.props;
 
@@ -77,14 +79,14 @@ class RequestLayer extends React.Component {
 
     // Assemble the result data array
     const matchCountPro = json.map(heroStat => heroStat.pro_pick || 0).reduce(sum, 0) / 10;
-    const matchCount8 = json.map(heroStat => heroStat['8_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount7 = json.map(heroStat => heroStat['7_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount6 = json.map(heroStat => heroStat['6_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount5 = json.map(heroStat => heroStat['5_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount4 = json.map(heroStat => heroStat['4_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount3 = json.map(heroStat => heroStat['3_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount2 = json.map(heroStat => heroStat['2_pick'] || 0).reduce(sum, 0) / 10;
-    const matchCount1 = json.map(heroStat => heroStat['1_pick'] || 0).reduce(sum, 0) / 10;
+    const matchCount8 = this.getMatchCountByRank('8_pick');
+    const matchCount7 = this.getMatchCountByRank('7_pick');
+    const matchCount6 = this.getMatchCountByRank('6_pick');
+    const matchCount5 = this.getMatchCountByRank('5_pick');
+    const matchCount4 = this.getMatchCountByRank('4_pick');
+    const matchCount3 = this.getMatchCountByRank('3_pick');
+    const matchCount2 = this.getMatchCountByRank('2_pick');
+    const matchCount1 = this.getMatchCountByRank('1_pick');
     const matchCountPublic = matchCount8 + matchCount7 + matchCount6 + matchCount5 + matchCount4 + matchCount3 + matchCount2 + matchCount1;
 
     const processedData = json.map((heroStat) => {

--- a/src/components/Heroes/index.jsx
+++ b/src/components/Heroes/index.jsx
@@ -48,6 +48,7 @@ class RequestLayer extends React.Component {
 
     // Assemble the result data array
     const matchCountPro = json.map(heroStat => heroStat.pro_pick || 0).reduce(sum, 0) / 10;
+    const matchCount8 = json.map(heroStat => heroStat['8_pick'] || 0).reduce(sum, 0) / 10;
     const matchCount7 = json.map(heroStat => heroStat['7_pick'] || 0).reduce(sum, 0) / 10;
     const matchCount6 = json.map(heroStat => heroStat['6_pick'] || 0).reduce(sum, 0) / 10;
     const matchCount5 = json.map(heroStat => heroStat['5_pick'] || 0).reduce(sum, 0) / 10;
@@ -65,6 +66,7 @@ class RequestLayer extends React.Component {
         hero_id: heroStat.id,
         heroName: (heroes[heroStat.id] && heroes[heroStat.id].localized_name) || '',
         matchCountPro,
+        matchCount8,
         matchCount7,
         matchCount6,
         matchCount5,
@@ -76,6 +78,7 @@ class RequestLayer extends React.Component {
         pickRatePro,
         banRatePro,
         winRatePro: (heroStat.pro_win || 0) / heroStat.pro_pick,
+        pickRate8: (heroStat['8_pick'] || 0) / matchCount8,
         pickRate7: (heroStat['7_pick'] || 0) / matchCount7,
         pickRate6: (heroStat['6_pick'] || 0) / matchCount6,
         pickRate5: (heroStat['5_pick'] || 0) / matchCount5,
@@ -83,6 +86,7 @@ class RequestLayer extends React.Component {
         pickRate3: (heroStat['3_pick'] || 0) / matchCount3,
         pickRate2: (heroStat['2_pick'] || 0) / matchCount2,
         pickRate1: (heroStat['1_pick'] || 0) / matchCount1,
+        winRate8: (heroStat['8_win'] || 0) / heroStat['8_pick'],
         winRate7: (heroStat['7_win'] || 0) / heroStat['7_pick'],
         winRate6: (heroStat['6_win'] || 0) / heroStat['6_pick'],
         winRate5: (heroStat['5_win'] || 0) / heroStat['5_pick'],

--- a/src/components/Table/TableHeaderColumn.jsx
+++ b/src/components/Table/TableHeaderColumn.jsx
@@ -21,7 +21,8 @@ const HeaderCellSortIconWrapper = styled.div`
   height: 14px;
   margin-left: 0px;
   position: relative;
-  width: 14px;
+  width: 10px;
+  left: -3px;
 `;
 
 const TableHeaderColumn = ({

--- a/src/components/Table/TableHeaderColumn.jsx
+++ b/src/components/Table/TableHeaderColumn.jsx
@@ -12,6 +12,11 @@ const HeaderCellContent = styled.div`
   position: relative;
 `;
 
+const HeaderCellImageContent = styled.img`
+  height: 30px;
+  width: 30px;
+`;
+
 const HeaderCellSortIconWrapper = styled.div`
   height: 14px;
   margin-left: 0px;
@@ -44,9 +49,17 @@ const TableHeaderColumn = ({
           { !column.tooltip ? column.displayName : (
             <Tooltip title={column.tooltip}>
               <HeaderCellContent>
-                <span>
-                  {column.displayName}
-                </span>
+                {column.displayIcon
+                  ?
+                    <React.Fragment>
+                      <span> {column.displayName} </span>
+                      <HeaderCellImageContent src={column.displayIcon} />
+                    </React.Fragment>
+                  :
+                    <span>
+                      {column.displayName}
+                    </span>
+                }
                 {column.sortFn && (
                   <HeaderCellSortIconWrapper>
                     {getSortIcon(sortState, sortField, column.field, { height: 12, width: 12 })}

--- a/src/components/Table/TableHeaderColumn.jsx
+++ b/src/components/Table/TableHeaderColumn.jsx
@@ -13,8 +13,8 @@ const HeaderCellContent = styled.div`
 `;
 
 const HeaderCellImageContent = styled.img`
-  height: 30px;
-  width: 30px;
+  height: 24px;
+  width: 24px;
 `;
 
 const HeaderCellSortIconWrapper = styled.div`

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -35,6 +35,8 @@ export default {
   tableHeaderSurfaceColor: 'rgba(0, 0, 0, .3)',
   tableRowOddSurfaceColor: 'rgba(255, 255, 255, .019)',
   tableRowEvenSurfaceColor: 'rgba(0, 0, 0, .019)',
+  colorImmortal: 'rgba(17,17,35,0.65)',
+  colorImmortalAlt: 'rgba(17,17,35,0.45)',
   colorDivine: 'rgba(33, 41, 69, 0.45)',
   colorDivineAlt: 'rgba(33, 41, 69, 0.65)',
   colorAncient: 'rgba(82, 52, 91, 0.45)',


### PR DESCRIPTION
Added immortal rank tier and rank tier icons to hero page.

There's currently a bug I'm having troubles with - is someone able to help? The table isn't rendering the last few columns. This is due to the CSS on 'innerContainer', but I have no idea how to fix this and don't want to break all table. When disabling the beneath, table renders, but doesn't appear to adjust accordingly.

@media only screen and (min-width: 1200px)
<style>
.ioVduP .innerContainer {
    /* overflow-x: hidden !important; */
}
<style>
.ioVduP .innerContainer {
    /* overflow-y: hidden !important; */
    /* overflow-x: auto !important; */
}