### PR TITLE
fix the href of the logout button in the sidebar menu

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -245,7 +245,7 @@ const Header = ({
                       <ListItemText primary={strings.app_my_profile} />
                     </ListItem>
                   </DrawerLink>
-                  <DrawerLink to={`${process.env.REACT_APP_API_HOST}/logout`}>
+                  <DrawerLink as="a" href={`${process.env.REACT_APP_API_HOST}/logout`}>
                     <ListItem button onClick={() => setMenuState(false)}>
                       <ListItemText primary={strings.app_logout} />
                     </ListItem>


### PR DESCRIPTION
I noticed a little bug with the logout button in the sidebar menu, witch is that the href on the button was wrong.
![odweb_logout_btn_bug](https://user-images.githubusercontent.com/54400788/71389651-ef515c00-2605-11ea-8924-ded02605f2fe.jpg)
![odweb_logout_btn_fix](https://user-images.githubusercontent.com/54400788/71389655-f8422d80-2605-11ea-8e4a-c32ee0c8b901.png)

