### PR TITLE
fix(utility): fix formatGraphValueData to handle 0

### DIFF
--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -917,7 +917,7 @@ export function getLocalizedMonthStrings() {
 }
 
 export function formatGraphValueData(data, histogramName) {
-  if (!data) return '';
+  if (data !== 0 && !data) return '';
 
   switch (histogramName) {
     case 'duration':


### PR DESCRIPTION
Tooltips of histogram do not show x-value when it is 0.
It is because `!data` mistakenly judges 0 as invalid data and returns an empty string.
I fixed this.

![image](https://user-images.githubusercontent.com/22640673/73122188-642d0280-3fc5-11ea-9d8d-d3530b74b226.png)

![image](https://user-images.githubusercontent.com/22640673/73122202-80c93a80-3fc5-11ea-93dc-f5fc7a256e69.png)
