### PR TITLE
Fix body layout to prevent white offset when tooltips were opened once

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,115 +1,125 @@
 const path = require('path');
 
 const commonRules = {
-  "max-len": ["error", { "code": 180, "ignoreTemplateLiterals": true, "ignoreStrings": true }],
-  "no-mixed-operators": ["error", {
-    "allowSamePrecedence": true
-  }],
-  "no-shadow": 1,
-  "jsx-a11y/anchor-is-valid": ["warn", {
-    "components": ["Link"],
-    "specialLink": ["to"],
-  }],
-  "react/no-array-index-key": 1,
-  "react/require-default-props": 0,
-  'import/no-extraneous-dependencies': [
-    "error",
-    {
-      devDependencies: [
-        '.storybook/**',
-        'src/stories/**'
-      ]
-    }
+  'max-len': [
+    'error',
+    { code: 180, ignoreTemplateLiterals: true, ignoreStrings: true },
   ],
-  "react/sort-comp": [2],
-  "react/jsx-fragments": "off",
-  "react/jsx-curly-newline": "off",
-  "react/static-property-placement": "off",
-  "react/jsx-props-no-spreading": "off",
-  "react/destructuring-assignment": "off",
-  "react/prop-types": "off",
-  "react/no-access-state-in-setstate" : "off",
-  "react/button-has-type": "off",
-  "max-classes-per-file": 'off',
-  "import/no-cycle": "off",
-}
+  'no-mixed-operators': [
+    'error',
+    {
+      allowSamePrecedence: true,
+    },
+  ],
+  'no-shadow': 1,
+  'jsx-a11y/anchor-is-valid': [
+    'warn',
+    {
+      components: ['Link'],
+      specialLink: ['to'],
+    },
+  ],
+  'react/no-array-index-key': 1,
+  'react/require-default-props': 0,
+  'import/no-extraneous-dependencies': [
+    'error',
+    {
+      devDependencies: ['.storybook/**', 'src/stories/**'],
+    },
+  ],
+  'react/sort-comp': [2],
+  'react/jsx-fragments': 'off',
+  'react/jsx-curly-newline': 'off',
+  'react/static-property-placement': 'off',
+  'react/jsx-props-no-spreading': 'off',
+  'react/destructuring-assignment': 'off',
+  'react/prop-types': 'off',
+  'react/no-access-state-in-setstate': 'off',
+  'react/button-has-type': 'off',
+  'max-classes-per-file': 'off',
+  'import/no-cycle': 'off',
+};
 
 module.exports = {
-  "parser": "babel-eslint",
-  "env": {
-    "browser": true,
-    "jest": true,
+  parser: 'babel-eslint',
+  env: {
+    browser: true,
+    jest: true,
   },
-  "settings": {
-    "import/resolver": {
+  settings: {
+    'import/resolver': {
       node: {
         paths: [path.resolve(__dirname, './src')],
       },
     },
   },
-  "extends": [
-    "airbnb",
-  ],
-  "rules": {
+  extends: ['airbnb', 'prettier'],
+  rules: {
     ...commonRules,
-    "import/named": ["error"],
-    "react/state-in-constructor": "off",
-    "react/destructuring-assignment": "off",
-    "react/prop-types": "off",
-    "react/no-access-state-in-setstate" : "off",
-    "react/button-has-type": "off",
-    "max-classes-per-file": 'off',
-    "import/no-cycle": "off",
-    "arrow-parens": "off",
-    "operator-linebreak": "off",
-    "react/jsx-wrap-multilines": "off",
-    "react/jsx-one-expression-per-line": "off",
-    "object-curly-newline": "off",
-    "no-else-return": "off",
-    "implicit-arrow-linebreak": "off",
-    "prefer-object-spread": "off",
-    "lines-between-class-members": "off",
-    "react/jsx-tag-spacing": "off",
-    "import/no-useless-path-segments": "off",
-    "no-dupe-class-members": "off"
+    'import/named': ['error'],
+    'react/state-in-constructor': 'off',
+    'react/destructuring-assignment': 'off',
+    'react/prop-types': 'off',
+    'react/no-access-state-in-setstate': 'off',
+    'react/button-has-type': 'off',
+    'max-classes-per-file': 'off',
+    'import/no-cycle': 'off',
+    'arrow-parens': 'off',
+    'operator-linebreak': 'off',
+    'react/jsx-wrap-multilines': 'off',
+    'react/jsx-one-expression-per-line': 'off',
+    'object-curly-newline': 'off',
+    'no-else-return': 'off',
+    'implicit-arrow-linebreak': 'off',
+    'prefer-object-spread': 'off',
+    'lines-between-class-members': 'off',
+    'react/jsx-tag-spacing': 'off',
+    'import/no-useless-path-segments': 'off',
+    'no-dupe-class-members': 'off',
   },
-  "overrides": [
+  overrides: [
     {
-      "files": ["./src/**/*.ts","./src/**/*.tsx"],
-      "env": { "browser": true, "jest": true},
-      "extends": [
-        "airbnb",
-        "plugin:import/typescript",
-        "plugin:@typescript-eslint/recommended",
+      files: ['./src/**/*.ts', './src/**/*.tsx'],
+      env: { browser: true, jest: true },
+      extends: [
+        'airbnb',
+        'plugin:import/typescript',
+        'plugin:@typescript-eslint/recommended',
       ],
-      "parser": "@typescript-eslint/parser",
-      "parserOptions": {
-        "ecmaFeatures": { "jsx": true },
-        "sourceType": "module",
-        "project": "./tsconfig.json"
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+        project: './tsconfig.json',
       },
-      "plugins": ["react", "@typescript-eslint"],
-      "rules": {
+      plugins: ['react', '@typescript-eslint'],
+      rules: {
         ...commonRules,
-        "@typescript-eslint/consistent-type-definitions": ["error", "type"],
-        "@typescript-eslint/no-inferrable-types": ["error", {"ignoreProperties": true, "ignoreParameters": false}],
-        "@typescript-eslint/interface-name-prefix": ["error", { "prefixWithI": "never" }],
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "no-useless-constructor": "off",
-        "@typescript-eslint/no-useless-constructor": "error",
-        "@typescript-eslint/prefer-optional-chain": "error",
-        "@typescript-eslint/prefer-nullish-coalescing": "error",
-        'react/jsx-filename-extension': [1, { 'extensions': ['.ts', '.tsx'] }],
-        "import/prefer-default-export": "off",
-        "react/state-in-constructor": "off",
-        "import/extensions": "off",
-        "import/no-unresolved": "off",
-        "semi": "off",
-        "arrow-body-style": "off",
-        "@typescript-eslint/member-delimiter-style": "off",
-        "@typescript-eslint/no-use-before-define": "off",
-        "import/order": "off",
+        '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+        '@typescript-eslint/no-inferrable-types': [
+          'error',
+          { ignoreProperties: true, ignoreParameters: false },
+        ],
+        '@typescript-eslint/interface-name-prefix': [
+          'error',
+          { prefixWithI: 'never' },
+        ],
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'error',
+        '@typescript-eslint/prefer-optional-chain': 'error',
+        '@typescript-eslint/prefer-nullish-coalescing': 'error',
+        'react/jsx-filename-extension': [1, { extensions: ['.ts', '.tsx'] }],
+        'import/prefer-default-export': 'off',
+        'react/state-in-constructor': 'off',
+        'import/extensions': 'off',
+        'import/no-unresolved': 'off',
+        semi: 'off',
+        'arrow-body-style': 'off',
+        '@typescript-eslint/member-delimiter-style': 'off',
+        '@typescript-eslint/no-use-before-define': 'off',
+        'import/order': 'off',
       },
-    }
-  ]
+    },
+  ],
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "jsxSingleQuote": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17798,6 +17798,23 @@
         "object.entries": "^1.1.0"
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-config-react-app": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "cross-env": "^6.0.3",
     "eslint": "^6.6.0",
     "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.7.0",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -21,7 +21,7 @@ import Matches from '../Matches';
 import Meta from '../Meta';
 import Player from '../Player';
 import Predictions from '../Predictions';
-// import Assistant from '../Assistant';
+// import Assistant from "../Assistant";
 import Records from '../Records';
 import Request from '../Request';
 import Scenarios from '../Scenarios';
@@ -37,11 +37,15 @@ const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  left: ${props => (props.open ? '256px' : '0px')};
-  margin-top: ${props => (props.location.pathname === '/' ? '-56px' : '0px')};
-  background-image: ${props => (props.location.pathname === '/' ? 'url("/assets/images/home-background.png")' : '')};
-  background-position: ${props => (props.location.pathname === '/' ? 'center top' : '')};
-  background-repeat: ${props => (props.location.pathname === '/' ? 'no-repeat' : '')};
+  left: ${(props) => (props.open ? '256px' : '0px')};
+  margin-top: 0px;
+  background-image: ${(props) =>
+    props.location.pathname === '/'
+      ? 'url("/assets/images/home-background.png")'
+      : ''};
+  background-position: center top -56px;
+  background-repeat: ${(props) =>
+    props.location.pathname === '/' ? 'no-repeat' : ''};
 
   #back2Top {
     position: fixed;
@@ -54,7 +58,7 @@ const StyledDiv = styled.div`
     text-align: center;
     outline: none;
     border: none;
-    background-color: rgba(0,0,0,0.3);
+    background-color: rgba(0, 0, 0, 0.3);
     width: 40px;
     font-size: 14px;
     border-radius: 2px;
@@ -63,7 +67,7 @@ const StyledDiv = styled.div`
     opacity: 0;
     display: block;
     pointer-events: none;
-    -webkit-transform: translate3d(0,0,0);
+    -webkit-transform: translate3d(0, 0, 0);
     padding: 3px;
     transition: opacity 0.3s ease-in-out;
 
@@ -101,10 +105,7 @@ const AdBannerDiv = styled.div`
 `;
 
 const App = (props) => {
-  const {
-    strings,
-    location,
-  } = props;
+  const { strings, location } = props;
 
   const back2Top = React.useRef();
 
@@ -113,7 +114,10 @@ const App = (props) => {
       let wait = false;
       const { current } = back2Top;
       if (!wait) {
-        if (document.body.scrollTop > 1000 || document.documentElement.scrollTop > 1000) {
+        if (
+          document.body.scrollTop > 1000 ||
+          document.documentElement.scrollTop > 1000
+        ) {
           current.style.opacity = 1;
           current.style.pointerEvents = 'auto';
         } else {
@@ -149,20 +153,28 @@ const App = (props) => {
         />
         <Header location={location} />
         <AdBannerDiv>
-          { includeAds &&
+          {includeAds && (
             <a href="http://www.vpgame.com/?lang=en_us">
               <img src="/assets/images/vp-banner.jpg" alt="" />
             </a>
-          }
+          )}
         </AdBannerDiv>
         <StyledBodyDiv {...props}>
           <Switch>
             <Route exact path="/" component={Home} />
             <Route exact path="/matches/:matchId?/:info?" component={Matches} />
-            <Route exact path="/players/:playerId/:info?/:subInfo?" component={Player} />
+            <Route
+              exact
+              path="/players/:playerId/:info?/:subInfo?"
+              component={Player}
+            />
             <Route exact path="/heroes/:heroId?/:info?" component={Heroes} />
             <Route exact path="/teams/:teamId?/:info?" component={Teams} />
-            <Route exact path="/distributions/:info?" component={Distributions} />
+            <Route
+              exact
+              path="/distributions/:info?"
+              component={Distributions}
+            />
             <Route exact path="/request" component={Request} />
             <Route exact path="/status" component={Status} />
             <Route exact path="/explorer" component={Explorer} />
@@ -177,16 +189,17 @@ const App = (props) => {
           </Switch>
         </StyledBodyDiv>
         <AdBannerDiv>
-          { includeAds &&
+          {includeAds && (
             <div style={{ fontSize: '12px' }}>
               <a href="https://www.rivalry.com/opendota">
                 <img src="/assets/images/rivalry-banner.gif" alt="" />
               </a>
               <div>
-                {strings.home_sponsored_by} <a href="https://www.rivalry.com/opendota">Rivalry</a>
+                {strings.home_sponsored_by}{' '}
+                <a href="https://www.rivalry.com/opendota">Rivalry</a>
               </div>
             </div>
-          }
+          )}
         </AdBannerDiv>
         <Footer />
         <button
@@ -206,7 +219,7 @@ const App = (props) => {
   );
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   strings: state.app.strings,
 });
 

--- a/src/components/App/GlobalStyle.jsx
+++ b/src/components/App/GlobalStyle.jsx
@@ -4,15 +4,16 @@ import constants from '../constants';
 const GlobalStyle = createGlobalStyle([
   `
 body {
-  background-color: initial;
-  text-align: initial;
-  display: block;
-  justify-content: initial;
   align-items: initial;
-  height: initial;
-  width: initial;
-  margin: 0;
+  background-color: initial;
+  display: block;
   font-family: ${constants.fontFamily};
+  height: initial;
+  justify-content: initial;
+  margin: 0;
+  padding-right: 0 !important;
+  text-align: initial;
+  width: initial;
 }
 
 a {

--- a/src/components/App/GlobalStyle.jsx
+++ b/src/components/App/GlobalStyle.jsx
@@ -1,11 +1,12 @@
 import { createGlobalStyle } from 'styled-components';
 import constants from '../constants';
 
-const GlobalStyle = createGlobalStyle([`
+const GlobalStyle = createGlobalStyle([
+  `
 body {
   background-color: initial;
   text-align: initial;
-  display: initial;
+  display: block;
   justify-content: initial;
   align-items: initial;
   height: initial;
@@ -164,6 +165,7 @@ th {
   padding-left: 24px;
   padding-right: 24px;
 }
-`]);
+`,
+]);
 
 export default GlobalStyle;


### PR DESCRIPTION
This PR fixes #2386 - it adds some necessary css attributes to the body element so it doesn't cause this strange bug to appear when using `display: initial`. I also fixed some issues with the home page layout having a buggy offset.

(The text wasn't centered on the background image)

---

Additional: Since I use prettier for all of my work I added a prettier-config and a helper package that sets up prettier to work with eslint.