### PR TITLE
Fix forwarding warnings in LocalizationMenu component

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,10 +1,18 @@
-import { IconButton, List, ListItem, ListItemText, Menu, MenuItem, SwipeableDrawer } from '@material-ui/core';
+import {
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Menu,
+  MenuItem,
+  SwipeableDrawer,
+} from '@material-ui/core';
 import { BugReport, Menu as MenuIcon, Settings } from '@material-ui/icons';
 import LogOutButton from 'material-ui/svg-icons/action/power-settings-new';
 import ActionSearch from 'material-ui/svg-icons/action/search';
 import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -100,7 +108,7 @@ const DrawerLink = styled(Link)`
 
 const LinkGroup = ({ navbarPages }) => (
   <VerticalAlignToolbar>
-    {navbarPages.map(page => (
+    {navbarPages.map((page) => (
       <TabContainer key={page.key}>
         <Link to={page.to}>{page.label}</Link>
       </TabContainer>
@@ -114,18 +122,31 @@ LinkGroup.propTypes = {
 
 const SettingsGroup = ({ children }) => {
   const [anchorEl, setAnchorEl] = useState(null);
+  const buttonRef = useRef();
+
   const handleClose = useCallback(() => {
     setAnchorEl(undefined);
   }, [setAnchorEl]);
 
   return (
     <>
-      <IconButton color="inherit" onClick={e => setAnchorEl(e.currentTarget)}>
+      <IconButton
+        ref={buttonRef}
+        color="inherit"
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+      >
         <Settings />
       </IconButton>
-      <DropdownMenu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose} PaperProps={{ style: { maxHeight: 600 } }}>
-        {children}
-      </DropdownMenu>
+      {buttonRef.current && (
+        <DropdownMenu
+          anchorEl={buttonRef.current}
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+          PaperProps={{ style: { maxHeight: 600 } }}
+        >
+          {children}
+        </DropdownMenu>
+      )}
     </>
   );
 };
@@ -167,7 +188,12 @@ const AccountGroup = () => (
 );
 
 const ReportBug = ({ strings }) => (
-  <DropdownMenuItem component="a" href={REPORT_BUG_PATH} target="_blank" rel="noopener noreferrer">
+  <DropdownMenuItem
+    component="a"
+    href={REPORT_BUG_PATH}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
     <BugReport style={{ marginRight: 32, width: 24, height: 24 }} />
     {strings.app_report_bug}
   </DropdownMenuItem>
@@ -178,7 +204,11 @@ ReportBug.propTypes = {
 };
 
 const LogOut = ({ strings }) => (
-  <DropdownMenuItem component="a" href={`${process.env.REACT_APP_API_HOST}/logout`} rel="noopener noreferrer">
+  <DropdownMenuItem
+    component="a"
+    href={`${process.env.REACT_APP_API_HOST}/logout`}
+    rel="noopener noreferrer"
+  >
     <LogOutButton style={{ marginRight: 32, width: 24, height: 24 }} />
     {strings.app_logout}
   </DropdownMenuItem>
@@ -188,18 +218,15 @@ LogOut.propTypes = {
   strings: PropTypes.shape({}),
 };
 
-const Header = ({
-  location,
-  disableSearch,
-}) => {
+const Header = ({ location, disableSearch }) => {
   const [Announce, setAnnounce] = useState(null);
   const [menuIsOpen, setMenuState] = useState(false);
-  const small = useSelector(state => state.browser.greaterThan.small);
-  const user = useSelector(state => state.app.metadata.data.user);
-  const strings = useSelector(state => state.app.strings);
+  const small = useSelector((state) => state.browser.greaterThan.small);
+  const user = useSelector((state) => state.app.metadata.data.user);
+  const strings = useSelector((state) => state.app.strings);
 
   useEffect(() => {
-    import('../Announce').then(ann => setAnnounce(ann.default));
+    import('../Announce').then((ann) => setAnnounce(ann.default));
   }, []);
 
   const navbarPages = [
@@ -287,9 +314,13 @@ const Header = ({
               </div>
             </MenuLogoWrapper>
             <List>
-              {drawerPages.map(page => (
+              {drawerPages.map((page) => (
                 <DrawerLink key={`drawer__${page.to}`} to={page.to}>
-                  <ListItem button key={`drawer__${page.to}`} onClick={() => setMenuState(false)}>
+                  <ListItem
+                    button
+                    key={`drawer__${page.to}`}
+                    onClick={() => setMenuState(false)}
+                  >
                     <ListItemText primary={page.label} />
                   </ListItem>
                 </DrawerLink>
@@ -303,7 +334,10 @@ const Header = ({
                       <ListItemText primary={strings.app_my_profile} />
                     </ListItem>
                   </DrawerLink>
-                  <DrawerLink as="a" href={`${process.env.REACT_APP_API_HOST}/logout`}>
+                  <DrawerLink
+                    as="a"
+                    href={`${process.env.REACT_APP_API_HOST}/logout`}
+                  >
                     <ListItem button onClick={() => setMenuState(false)}>
                       <ListItemText primary={strings.app_logout} />
                     </ListItem>
@@ -311,7 +345,10 @@ const Header = ({
                 </>
               ) : (
                 <>
-                  <DrawerLink as="a" href={`${process.env.REACT_APP_API_HOST}/login`}>
+                  <DrawerLink
+                    as="a"
+                    href={`${process.env.REACT_APP_API_HOST}/login`}
+                  >
                     <ListItem button onClick={() => setMenuState(false)}>
                       <ListItemText primary={strings.app_login} />
                     </ListItem>
@@ -322,7 +359,7 @@ const Header = ({
           </MenuContent>
         </SwipeableDrawer>
       </ToolbarHeader>
-      { location.pathname !== '/' && Announce && <Announce /> }
+      {location.pathname !== '/' && Announce && <Announce />}
     </>
   );
 };

--- a/src/components/Localization/index.jsx
+++ b/src/components/Localization/index.jsx
@@ -1,11 +1,16 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { List, ListItem, ListItemIcon, ListItemText, Collapse } from '@material-ui/core';
+import React from 'react';
+import {
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Collapse,
+} from '@material-ui/core';
 import { ExpandMore, ExpandLess, Translate } from '@material-ui/icons';
 import styled from 'styled-components';
 import { langs } from '../../lang/index';
 import constants from '../constants';
+import { useStrings } from '../../hooks/useStrings.hook';
 
 const StyledListItem = styled(ListItem)`
   color: ${constants.primaryTextColor} !important;
@@ -20,56 +25,50 @@ const setLocalization = (event, key, payload) => {
   window.location.reload();
 };
 
-class LocalizationMenuItems extends Component {
-  constructor() {
-    super();
-    this.state = {
-      open: false,
-    };
-  }
+const LocalizationMenu = React.forwardRef(() => {
+  const strings = useStrings();
+  const [open, setOpen] = React.useState(false);
 
-  handleOnClick = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    this.setState({
-      open: !this.state.open,
-    });
-  };
+  const handleOnClick = React.useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(!open);
+    },
+    [open, setOpen],
+  );
 
-  render() {
-    const { strings } = this.props;
-    const { open } = this.state;
-    return (
-      <div style={{ minWidth: '200px' }}>
-        <List component="div">
-          <StyledListItem button onClick={this.handleOnClick}>
-            <StyledListItemIcon>
-              <Translate />
-            </StyledListItemIcon>
-            <ListItemText primary={strings.app_language} />
-            {open ? <ExpandLess /> : <ExpandMore />}
-          </StyledListItem>
-          <Collapse in={open} timeout="auto" unmountOnExit style={{ maxHeight: 300, overflow: 'auto' }}>
-            <List component="div" disablePadding>
-              {langs.map(lang => (
-                <StyledListItem button onClick={() => setLocalization(null, null, lang)} key={lang.translated}>
-                  <ListItemText primary={lang.native} />
-                </StyledListItem>
-              ))}
-            </List>
-          </Collapse>
-        </List>
-      </div>
-    );
-  }
-}
-
-const mapStateToProps = state => ({
-  strings: state.app.strings,
+  return (
+    <div style={{ minWidth: '200px' }}>
+      <StyledListItem button onClick={handleOnClick}>
+        <StyledListItemIcon>
+          <Translate />
+        </StyledListItemIcon>
+        <ListItemText primary={strings.app_language} />
+        {open ? <ExpandLess /> : <ExpandMore />}
+      </StyledListItem>
+      <List component="div">
+        <Collapse
+          in={open}
+          timeout="auto"
+          unmountOnExit
+          style={{ maxHeight: 300, overflow: 'auto' }}
+        >
+          <List component="div" disablePadding>
+            {langs.map((lang) => (
+              <StyledListItem
+                button
+                onClick={() => setLocalization(null, null, lang)}
+                key={lang.value}
+              >
+                <ListItemText primary={lang.native} />
+              </StyledListItem>
+            ))}
+          </List>
+        </Collapse>
+      </List>
+    </div>
+  );
 });
 
-LocalizationMenuItems.propTypes = {
-  strings: PropTypes.shape({}),
-};
-
-export default connect(mapStateToProps, null)(LocalizationMenuItems);
+export default LocalizationMenu;

--- a/src/hooks/useStrings.hook.js
+++ b/src/hooks/useStrings.hook.js
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+
+export const useStrings = () => {
+  const strings = useSelector((state) => state.app.strings);
+  return strings;
+};
+
+export default useStrings;


### PR DESCRIPTION
This issue fixes #2448. The problem was that material UIs new List and Menu components require a ref to be accessible as their child elements (for example MenuItem or ListItem always expose their refs).

I now:

* forward the ref from LocalizationMenu
* use hooks and FC for LocalizationMenu
* implement a `useStrings` hook to quickly access the apps strings instead of the connect function of redux