### PR TITLE
strip out html content from item descriptions in item tooltips

### DIFF
--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 import styled from 'styled-components';
 import items from 'dotaconstants/build/items.json';
 import constants from '../constants';
-import { styleValues } from '../../utility';
+import { styleValues, stripHTML } from '../../utility';
 
 const itemAbilities = {
   active: {
@@ -198,9 +198,9 @@ const ItemTooltip = ({ item, inflictor }) => (
     <Attributes>
       {(item.attrib).map((attrib) => (
         <Attribute key={attrib.key}>
-          <span id="header">{attrib.header} </span>
-          <span id="value">{`${attrib.value}`}</span>
-          <span id="footer"> {attrib.footer || ''}</span>
+          <span id="header">{stripHTML(attrib.header)} </span>
+          <span id="value">{`${stripHTML(attrib.value)} `}</span>
+          <span id="footer">{stripHTML(attrib.footer || '')}</span>
         </Attribute>
       ))}
     </Attributes>

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -927,3 +927,8 @@ export function formatGraphValueData(data, histogramName) {
       return data;
   }
 }
+
+export const HTML_REGEX = /(<([^>]+)>)/ig;
+export function stripHTML(string) {
+  return string.replace(HTML_REGEX, '');
+}


### PR DESCRIPTION
This PR fixes #2507 as it strips out HTML content from item tooltip attributes.

Still I think this should also happen on the server as the content produced by the server is not "clean".