### PR TITLE
Updated heatmap value scaling

### DIFF
--- a/src/components/Heatmap/Heatmap.jsx
+++ b/src/components/Heatmap/Heatmap.jsx
@@ -7,19 +7,15 @@ import DotaMap from '../DotaMap';
 /**
  * Adjust each x/y coordinate by the provided scale factor.
  * If max is provided, use that, otherwise, use local max of data.
- * Shift all values by the provided shift.
  * Returns the adjusted heatmap data.
  */
-function scaleAndExtrema(points, scalef, max, shift) {
-  // the max values should not deviate from the average by more than a factor of 25
-  const maxValue = (points.reduce((a, b) => a + b.value, 0) / points.length) * 25;
-
+function scaleAndExtrema(points, scalef, max) {
   const newPoints = points.map(p => ({
     x: Math.floor(p.x * scalef),
     y: Math.floor(p.y * scalef),
-    value: Math.min(p.value, maxValue) + shift,
+    value: Math.sqrt(p.value),
   }));
-  const vals = points.map(p => Math.min(p.value, maxValue));
+  const vals = newPoints.map(p => p.value);
   const localMax = Math.max(...vals);
   return {
     min: 0,
@@ -33,8 +29,7 @@ const drawHeatmap = ({
   width,
 }, heatmap) => {
   // scale points by width/127 units to fit to size of map
-  // offset points by 25 units to increase visibility
-  const adjustedData = scaleAndExtrema(points, width / 127, null, 25);
+  const adjustedData = scaleAndExtrema(points, width / 127, null);
   heatmap.setData(adjustedData);
 };
 


### PR DESCRIPTION
For a while now I've noticed that wardmaps often look weird, frequently being giant red blobs with no detailed information. The issue was that 25 was getting added to all nonzero values in the map, but this wasn't taken into account when calculating the max value for heatmap scaling. This could cause the heatmap's max value to be under 25, and thus _all_ data points get rendered as above the max.

I updated the calculations to no longer have that shift of 25. I also changed the scaling to be sqrt, rather than a hard cutoff at 25x the average value. Before/after comparisons (click for larger images):

~10 matches
[![](https://i.imgur.com/VECM53ib.png)](https://i.imgur.com/VECM53i.png) [![](https://i.imgur.com/e7wjDBbb.png)](https://i.imgur.com/e7wjDBb.png)

~100 matches
[![](https://i.imgur.com/7vK5KLqb.png)](https://i.imgur.com/7vK5KLq.png) [![](https://i.imgur.com/vTTsWmzb.png)](https://i.imgur.com/vTTsWmz.png)

~2000 matches (note increased detail in areas such as north of roshpit)
[![](https://i.imgur.com/ndFtpY1b.png)](https://i.imgur.com/ndFtpY1.png) [![](https://i.imgur.com/qLh1t1Qb.png)](https://i.imgur.com/qLh1t1Q.png)

~6000 matches (different player)
[![](https://i.imgur.com/nul7vZLb.png)](https://i.imgur.com/nul7vZL.png) [![](https://i.imgur.com/TkyUkyIb.png)](https://i.imgur.com/TkyUkyI.png)