### PR TITLE
Fix 7.23 map path

### DIFF
--- a/src/components/DotaMap/index.jsx
+++ b/src/components/DotaMap/index.jsx
@@ -11,7 +11,7 @@ const setMapSizeStyle = (width, maxWidth) => ({
 });
 
 const dotaMaps = [
-  { patch: '7.23', images: { jpg: '/assets/images/dota2/map/detailed_723.png', webp: '/assets/images/dota2/map/detailed_723.webp' } },
+  { patch: '7.23', images: { jpg: '/assets/images/dota2/map/detailed_723.jpg', webp: '/assets/images/dota2/map/detailed_723.webp' } },
   { patch: '7.20', images: { jpg: '/assets/images/dota2/map/detailed_720.jpg', webp: '/assets/images/dota2/map/detailed_720.webp' } },
   { patch: '7.07', images: { jpg: '/assets/images/dota2/map/detailed_707.jpg', webp: '/assets/images/dota2/map/detailed_707.webp' } },
   { patch: '7.00', images: { jpg: '/assets/images/dota2/map/detailed_700.jpg', webp: '/assets/images/dota2/map/detailed_700.webp' } },


### PR DESCRIPTION
Currently the 723 map links to the wrong space, leading to it not showing on the parsed page:
<img width="377" alt="image" src="https://user-images.githubusercontent.com/8315137/83304397-2b9c7000-a1d5-11ea-9171-e30321b2debe.png">

Goes to:
https://www.opendota.com/assets/images/dota2/map/detailed_723.png
Which is a 404

Should be
https://www.opendota.com/assets/images/dota2/map/detailed_723.jpg