### PR TITLE
fix: hint interpolation via regex

### DIFF
--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -235,7 +235,7 @@ const ItemTooltip = ({ item, inflictor }) => (
       }
       return null;
     })}
-    {item.hint && <Hint>{item.hint}</Hint>}
+    {item.hint && <Hint>{item.hint.map(hintLine => hintLine.replace(/[ a-zA-Z]+: %\w+%/g,""))}</Hint>}
     {item.lore && <Lore>{item.lore}</Lore>}
     {item.components &&
     <Components>


### PR DESCRIPTION
Tomes Used By Team: %%, Ability Range: %%, all such phrases inside
the Item Hint will be removed from the Item Tooltip using a replace
with regex.

Closes #2256