### PR TITLE
Improve 'Abilities Drafted' table contents.

### DIFF
--- a/src/actions/transformMatch.js
+++ b/src/actions/transformMatch.js
@@ -144,7 +144,7 @@ function generateVisionLog(match) {
 }
 
 function transformMatch(m) {
-  const { strings } = store.getState().app;
+  const { abilityIds, strings } = store.getState().app;
   const newPlayers = m.players.map((player) => {
     const newPlayer = {
       ...player,
@@ -229,7 +229,7 @@ function transformMatch(m) {
       const arr = [];
       if (player.ability_upgrades_arr) {
         player.ability_upgrades_arr.forEach((ability) => {
-          if (!arr.includes(ability) && ability < 5900) {
+          if (!arr.includes(ability) && abilityIds[ability] && abilityIds[ability].indexOf('special_bonus') === -1) {
             arr.push(ability);
           }
         });


### PR DESCRIPTION
-Previously the abilities that appear in the 'Abilities Drafted' table
were added if they had an ability id of less than 5900. This was okay
for most abilities, but it would include some talent upgrades and
exclude abilities from newer heroes such as Mars, Hoodwink, Dawnbreaker,
etc. since their ability ids are greater than 5900.
-Now the `abilities` array that is populated in transformMatch will
include ability upgrades regardless of the id value as long as the
ability name doesn't include 'special_bonus'.

Before:
![ad_before](https://user-images.githubusercontent.com/7128691/120565787-b274c180-c3c2-11eb-8f6b-81243989fddb.png)

After:
![ad_after](https://user-images.githubusercontent.com/7128691/120565806-ba346600-c3c2-11eb-81ab-95f71f9e30c4.png)
