### PR TITLE
2832 add aria labels to header elements

### DIFF
--- a/src/components/App/AppLogo.jsx
+++ b/src/components/App/AppLogo.jsx
@@ -17,7 +17,7 @@ const StyledLink = styled(Link)`
 `;
 
 const AppLogo = ({ size, strings, onClick }) => (
-  <StyledLink to="/" onClick={onClick}>
+  <StyledLink aria-label="Go to the Open Dota homepage" to="/" onClick={onClick}>
     <span style={{ fontSize: size }}>
       {strings.app_name && `<${strings.app_name}/>`}
     </span>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -165,21 +165,21 @@ const Footer = ({ strings }) => (
               href="https://play.google.com/store/apps/details?id=com.opendota.mobile&hl=en"
               style={{ position: 'relative', left: '13px', top: '12px' }}
             >
-              <img src="/assets/images/google_play_store.png" alt="" height="46px" />
+              <img src="/assets/images/google_play_store.png" alt="download the android app on google play store" height="46px" />
             </a>
             <a
               href="https://itunes.apple.com/us/app/opendota/id1354762555?ls=1&mt=8"
               style={{ position: 'relative', left: '20px', top: '5px' }}
             >
-              <img src="/assets/images/apple_app_store.png" alt="" height="31px" />
+              <img src="/assets/images/apple_app_store.png" alt="download the iOS app on the app store" height="31px" />
             </a>
           </div>
         </div>
         <small className="about">
-          {strings.app_description}
+          <span id="app-description">{strings.app_description}</span>
           {' - '}
-          {strings.app_powered_by}
-          <a href="http://steampowered.com" target="_blank" rel="noopener noreferrer">
+          <span id="app-powered-by">{strings.app_powered_by}</span>
+          <a href="http://steampowered.com" aria-describedby="app-description app-powered-by" target="_blank" rel="noopener noreferrer">
             <IconSteam />
           </a>
         </small>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -134,6 +134,7 @@ const SettingsGroup = ({ children }) => {
     <>
       <IconButton
         ref={buttonRef}
+        aria-label="settings menu"
         color="inherit"
         onClick={(e) => setAnchorEl(e.currentTarget)}
       >
@@ -161,7 +162,7 @@ const LogoGroup = ({ onMenuClick }) => (
   <div style={{ marginRight: 16 }}>
     <VerticalAlignToolbar>
       <MenuButtonWrapper>
-        <IconButton edge="start" color="inherit" onClick={onMenuClick}>
+        <IconButton aria-label="main menu" edge="start" color="inherit" onClick={onMenuClick}>
           <MenuIcon />
         </IconButton>
       </MenuButtonWrapper>

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -20,8 +20,15 @@ const Home = ({ strings }) => (
     <Why />
     <Sponsors />
     <BottomTextDiv>
-      {strings.home_background_by}
-      <a href="//www.artstation.com/artist/mikeazevedo" target="_blank" rel="noopener noreferrer"> Mike Azevedo</a>
+      <span id="bg-image-description">{strings.home_background_by}</span>
+      <a 
+        href="//www.artstation.com/artist/mikeazevedo" 
+        target="_blank" 
+        rel="noopener noreferrer" 
+        aria-describedby="bg-image-description" 
+        aria-label="Mike Azevedo on artstation.com"
+      > Mike Azevedo
+      </a> 
     </BottomTextDiv>
   </div>
 );

--- a/src/components/Home/Sponsors.jsx
+++ b/src/components/Home/Sponsors.jsx
@@ -42,14 +42,14 @@ const Sponsors = ({ strings }) => (
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img src="/assets/images/vp-logo.png" alt="" />
+        <img src="/assets/images/vp-logo.png" alt="VP Game home" />
       </a>
       <a
         href="https://www.openai.com/"
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img src="/assets/images/openai-logo.png" alt="" />
+        <img src="/assets/images/openai-logo.png" alt="Open AI home" />
       </a>
       {process.env.REACT_APP_ENABLE_RIVALRY &&
       <a

--- a/src/components/Search/SearchForm.jsx
+++ b/src/components/Search/SearchForm.jsx
@@ -64,6 +64,7 @@ class SearchForm extends React.Component {
       <form onSubmit={this.formSubmit} style={{ width: small ? '280px' : 'auto' }}>
         <TextField
           id="searchField"
+          aria-label={strings.search_title}
           hintText={strings.search_title}
           value={this.state.query}
           onChange={this.handleChange}


### PR DESCRIPTION
## Description
This pull request is in reference to [this open issue](https://github.com/odota/web/issues/2832) regarding accessibility improvements. Specifically this pull request adds aria labels to several key elements in the OpenDota web application header. It's important to note that this pull request doesn't have any visual impact on the existing UI. Comments are left on each update describing why it was necessary. 

This pull request fixes 3 site-wide critical accessibility issues detected by aXe.

<details><summary>Existing critical issues</summary>
<img width="1440" alt="Screen Shot 2021-09-30 at 9 05 18 PM" src="https://user-images.githubusercontent.com/15097156/135722930-d556b6cf-c115-430c-bc3f-bb8518c85300.png">
</details>

<details><summary>With fixes, 0 remaining critical issues</summary>
<img width="353" alt="Screen Shot 2021-10-02 at 10 11 53 AM" src="https://user-images.githubusercontent.com/15097156/135722950-f01ef9b1-2b02-4175-b9aa-66a822346a75.png">
</details>

**Edit:** I've gone ahead and included several more updates in the sponsor and footer sections of the homepage, since they were simple to add. 