### PR TITLE
Fix chat filter toggling behaviour

### DIFF
--- a/src/components/Match/Chat/Chat.jsx
+++ b/src/components/Match/Chat/Chat.jsx
@@ -291,6 +291,7 @@ class Chat extends React.Component {
       spam: true,
 
       playing: null,
+      messages: null,
     };
 
     this.filters = {
@@ -335,6 +336,8 @@ class Chat extends React.Component {
         disabled: () => false,
       },
     };
+
+    this.state.messages = this.filter();
   }
 
   audio = (message, index) => {
@@ -353,26 +356,28 @@ class Chat extends React.Component {
     }, 500);
   };
 
-  filter = (key) => {
+  toggleFilter = (key) => {
     if (key !== undefined) {
-      this.setState({ ...this.state, [key]: !this.state[key] });
+      this.setState((state) => {return {[key]: !state[key]}}, () => {this.setState({messages: this.filter()})});
     }
+  }
 
-    this.messages = this.raw.slice();
+  filter = () => {
+    const messages = this.raw.slice();
 
     Object.keys(this.filters).forEach((k) => {
       if (!this.state[k]) {
         this.filters[k].f().forEach((obj) => {
-          const index = this.messages.indexOf(obj);
+          const index = messages.indexOf(obj);
           if (index >= 0) {
-            this.messages.splice(index, 1);
+            messages.splice(index, 1);
           }
         });
       }
     });
 
     // sort by time, considering spam
-    this.messages.sort((a, b) => {
+    messages.sort((a, b) => {
       const timeDiff = Number(a.time) - Number(b.time);
       if (timeDiff === 0) {
         if (a.spam === b.spam) {
@@ -382,19 +387,17 @@ class Chat extends React.Component {
       }
       return timeDiff;
     });
+
+    return messages
   };
 
   render() {
-    if (!this.messages) {
-      this.filter();
-    }
-
     const emoteKeys = Object.keys(emotes);
 
     const Messages = ({ strings }) => (
       <div>
         <ul className="Chat">
-          {this.messages.map((msg, index) => {
+          {this.state.messages.map((msg, index) => {
             const hero = heroes[msg.heroID];
             const rad = isRadiant(msg.player_slot);
             const spec = isSpectator(msg.slot);
@@ -514,7 +517,7 @@ class Chat extends React.Component {
               <ul>
                 {categories[cat].map((filter) => {
                   const len = filter.f().length;
-                  const lenFiltered = filter.f(this.messages).length;
+                  const lenFiltered = filter.f(this.state.messages).length;
 
                   return (
                     <li key={filter.name}>
@@ -529,7 +532,7 @@ class Chat extends React.Component {
                           </span>
                         }
                         checked={this.state[filter.name]}
-                        onCheck={() => this.filter(filter.name)}
+                        onCheck={() => this.toggleFilter(filter.name)}
                         checkedIcon={<Visibility />}
                         uncheckedIcon={<VisibilityOff />}
                         disabled={filter.disabled()}


### PR DESCRIPTION
Fixes #2842 .

The issue was that `messages` was being updated based on the old filter states as `setState` works asynchronously.
To fix it, I updated `messages` using the `setState` callback. I also moved `messages` to `state` as I think it should belong there. 

However, this lead to a slightly unelegant method of initialising it on line 240. Setting it directly inside `this.state = {messages: this.filter()}` didn't work due to the way `this` works I guess. Please let me know if there's a better way of doing that, thanks!