### PR TITLE
2832 - Combo Page aria labels

### DIFF
--- a/src/components/Combos/Combos.jsx
+++ b/src/components/Combos/Combos.jsx
@@ -44,6 +44,7 @@ const InputFilter = ({
     <div className="container">
       <ActionSearch style={{ marginRight: 6, opacity: '.6', verticalAlign: 'middle' }} />
       <TextField
+        aria-label={filterText}
         ref={setInputRef}
         hintText={filterText}
         value={value}
@@ -51,6 +52,7 @@ const InputFilter = ({
         style={{ width: 150 }}
       />
       <div
+        aria-label="clear hero filter"
         className="reset-button"
         onClick={reset}
         onKeyPress={reset}
@@ -72,11 +74,13 @@ const HeroSelector = ({
   teamAFull,
   teamBFull,
   isFiltered,
+  heroName
 }) => (
   <StyledHeroSelector selected={selected} isFiltered={isFiltered}>
     <HeroImage id={id} imageSizeSuffix={IMAGESIZE_ENUM.VERT.suffix}/>
     <div className={`ts-container ${selected ? 'selected' : ''}`}>
       <div
+        aria-label={`${heroName} team A`}
         className={`ts ts-left ${teamAFull ? 'no-event' : ''}`}
         onClick={handleHeroSelection(id.toString(), 'teamA')}
         onKeyPress={handleHeroSelection(id.toString(), 'teamA')}
@@ -86,6 +90,7 @@ const HeroSelector = ({
         {'A'}
       </div>
       <div
+        aria-label={`${heroName} team B`}
         className={`ts ts-right ${teamBFull ? 'no-event' : ''}`}
         onClick={handleHeroSelection(id.toString(), 'teamB')}
         onKeyPress={handleHeroSelection(id.toString(), 'teamB')}

--- a/src/components/Combos/Styles.jsx
+++ b/src/components/Combos/Styles.jsx
@@ -46,7 +46,6 @@ export const StyledInputFilter = styled.div`
     opacity: 0.5;
     cursor: pointer;
     margin-left: 10px;
-    outline: none;
 
     &:hover {
       opacity: 1;


### PR DESCRIPTION
## Description
This pull request adds aria labels to these elements on the Combo page: Hero Filter, Reset Btn, team select buttons. This is needed because screen reader users currently have no context around what these elements do. As seen in attached screenshots, screen readers will read out ambiguous labels. With these fixes, screen readers provide more understandable context around what each element actually does. 

<details><summary>Current VoiceOver readout</summary>

<img width="740" alt="Screen Shot 2021-10-16 at 12 06 09 PM" src="https://user-images.githubusercontent.com/15097156/137598680-556728eb-f5f9-4f3a-a4c6-5eafb02b66b1.png">
<img width="745" alt="Screen Shot 2021-10-16 at 12 10 46 PM" src="https://user-images.githubusercontent.com/15097156/137598682-c56188e8-100f-48f9-a8f3-6ae6cafc224d.png">
<img width="704" alt="Screen Shot 2021-10-16 at 12 13 09 PM" src="https://user-images.githubusercontent.com/15097156/137598685-1504292d-0a6d-4e29-98df-131ab88bc3ed.png">

</details>

<details><summary>VoiceOver readout with proposed fix</summary>

<img width="1081" alt="Screen Shot 2021-10-16 at 12 10 00 PM" src="https://user-images.githubusercontent.com/15097156/137598702-93cc3368-ca3e-405f-8783-f523310b9ab1.png">
<img width="962" alt="Screen Shot 2021-10-16 at 12 12 14 PM" src="https://user-images.githubusercontent.com/15097156/137598705-c2e72554-8f00-40f4-961b-b6346f392f1c.png">
<img width="682" alt="Screen Shot 2021-10-16 at 12 23 37 PM" src="https://user-images.githubusercontent.com/15097156/137598706-a9e7f48f-08e1-496a-b196-13e39fdbc610.png">


</details>