### PR TITLE
2832 fix drawer menu focus

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -103,8 +103,15 @@ const MenuLogoWrapper = styled.div`
   padding: 24px 0;
 `;
 
+
+
 const DrawerLink = styled(Link)`
   color: ${constants.textColorPrimary};
+
+   & li:hover {
+      background-color: rgba(0, 0, 0, 0.08);
+      transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; 
+  }
 `;
 
 const LinkGroup = ({ navbarPages }) => (
@@ -318,12 +325,12 @@ const Header = ({ location, disableSearch }) => {
             </MenuLogoWrapper>
             <List>
               {drawerPages.map((page) => (
-                <DrawerLink key={`drawer__${page.to}`} to={page.to}>
-                  <ListItem
-                    button
-                    key={`drawer__${page.to}`}
-                    onClick={() => setMenuState(false)}
-                  >
+                <DrawerLink 
+                  key={`drawer__${page.to}`} 
+                  to={page.to}
+                  onClick={() => setMenuState(false)}
+                >
+                  <ListItem>
                     <ListItemText primary={page.label} />
                   </ListItem>
                 </DrawerLink>


### PR DESCRIPTION
## Description
This pull request fixes keyboard focus on the drawer menu by refactoring some of the existing code. Currently, when tabbing through the opened drawer menu, each item contains both an `a` tag and an embedded, focusable div. This causes keyboard navigation to first focus on the `a` tag, and then the div. This adds extra unnecessary keystrokes for those that rely on keyboard navigation. 

## Why it matters
People who use keyboard navigation should be easily able to traverse a menu without experiencing extra keystrokes. 

## Things to note
- Though this refactors how some of the menu items are constructed, visual parity is maintained with what is currently in production. 

<details><summary>Current production UI</summary>

<img width="342" alt="Screen Shot 2021-10-23 at 11 48 52 AM" src="https://user-images.githubusercontent.com/15097156/138565886-b1f818ec-4feb-45ee-80e4-c64d6698ad35.png">

</details>

<details><summary>Proposed change locally</summary>

<img width="288" alt="Screen Shot 2021-10-23 at 11 49 00 AM" src="https://user-images.githubusercontent.com/15097156/138565960-1009398d-a5ec-4eb3-96f2-832ad904b4e3.png">


</details>