### PR TITLE
Pickbans UI improvements

### DIFF
--- a/src/components/Match/Overview/Overview.jsx
+++ b/src/components/Match/Overview/Overview.jsx
@@ -43,6 +43,7 @@ const Overview = (strings, gosuUrl, gosuIcon) => {
     content: match => (
       <div>
         <TeamTable
+          gameMode={match.game_mode}
           players={match.players}
           columns={overviewColumns(match)}
           heading={strings.heading_overview}

--- a/src/components/Match/Overview/PicksBans.jsx
+++ b/src/components/Match/Overview/PicksBans.jsx
@@ -40,6 +40,7 @@ margin-top: -20px;
 img {
   position: relative;
   height: 29px;
+  width:100%;
   box-shadow: 0 0 5px ${constants.defaultPrimaryColor};
   margin-right: 0;
   z-index: 0;
@@ -49,7 +50,6 @@ img {
   }
 
   @media only screen and (max-width: 716px) {
-    width: 42px;
     object-fit: cover;
   }
 }
@@ -70,21 +70,26 @@ img {
 }
 `;
 
-const PicksBans = ({ data, strings, style }) => (
-  <Styled style={style}>
-    <div className="PicksBans">
-      {data.map(pb => (
-        <section key={pb.order}>
-          <HeroImage id={pb.hero_id} imageSizeSuffix={IMAGESIZE_ENUM.SMALL.suffix} data-isPick={pb.is_pick} />
-          {!pb.is_pick && <div className="ban" />}
-          <aside>
-            {pb.is_pick ? strings.match_pick : strings.match_ban} <b>{pb.order + 1}</b>
-          </aside>
-        </section>
-      ))}
-    </div>
-  </Styled>
-);
+
+const PicksBans = ({ gameMode, data, strings, style }) => {
+  let counter = 0;
+  console.log(gameMode);
+  return (
+    <Styled style={style}>
+      <div className="PicksBans">
+        {data.map(pb => (
+          <section key={pb.order}>
+            <HeroImage id={pb.hero_id} imageSizeSuffix={IMAGESIZE_ENUM.SMALL.suffix} data-isPick={pb.is_pick} />
+            {!pb.is_pick && <div className="ban" />}
+            <aside>
+              {pb.is_pick ? strings.match_pick : strings.match_ban} <b>{gameMode === 22 ? pb.is_pick ? pb.order + 1 : counter+=1 : pb.order + 1}</b>
+            </aside>
+          </section>
+        ))}
+      </div>
+    </Styled>
+  )
+};
 
 PicksBans.propTypes = {
   data: PropTypes.arrayOf({}),

--- a/src/components/Match/Overview/PicksBans.jsx
+++ b/src/components/Match/Overview/PicksBans.jsx
@@ -31,10 +31,6 @@ margin-top: -20px;
       line-height: 1.6;
     }
   }
-
-  @media only screen and (max-width: 716px) {
-    margin: 0;
-  }
 }
 
 img {

--- a/src/components/Match/TeamTable.jsx
+++ b/src/components/Match/TeamTable.jsx
@@ -48,6 +48,7 @@ const filterMatchPlayers = (players, team = '') =>
 
 class TeamTable extends React.Component {
   static propTypes = {
+    gameMode: PropTypes.number,
     players: PropTypes.arrayOf({}),
     columns: PropTypes.arrayOf({}),
     heading: PropTypes.string,
@@ -106,6 +107,7 @@ class TeamTable extends React.Component {
 
   render() {
     const {
+      gameMode,
       players = [],
       columns,
       heading = '',
@@ -147,7 +149,14 @@ class TeamTable extends React.Component {
         <div className="teamtable teamtable-radiant">
           <Table data={filterMatchPlayers(players, 'radiant')} {...tableProps} />
         </div>
-        {picksBans && picksBans.length > 0 && <PicksBans data={picksBans.filter(pb => pb.team === 0)} /> /* team 0 - radiant */}
+        {gameMode === 22 ?
+        <>
+          {picksBans && picksBans.length > 0 && <PicksBans gameMode={gameMode} data={picksBans.filter(pb => pb.team === 0 && pb.is_pick)} /> /* team 0 - radiant */}
+          {picksBans && picksBans.length > 0 && <PicksBans gameMode={gameMode} data={picksBans.filter(pb => pb.team === 0 && !pb.is_pick)} /> /* team 0 - radiant */}
+        </>
+        :
+          picksBans && picksBans.length > 0 && <PicksBans gameMode={gameMode} data={picksBans.filter(pb => pb.team === 0)} /> /* team 0 - radiant */
+        }
         <Heading
           title={`${getTeamName(direTeam, false)} - ${heading}`}
           winner={!hideWinnerTag && !radiantWin}
@@ -155,7 +164,7 @@ class TeamTable extends React.Component {
         <div className="teamtable teamtable-dire">
           <Table data={filterMatchPlayers(players, 'dire')} {...tableProps} />
         </div>
-        {picksBans && picksBans.length > 0 && <PicksBans data={picksBans.filter(pb => pb.team === 1)} /> /* team 1 - dire */}
+        {picksBans && picksBans.length > 0 && <PicksBans gameMode={gameMode} data={picksBans.filter(pb => pb.team === 1)} /> /* team 1 - dire */}
       </StyledDiv>
     );
   }


### PR DESCRIPTION
Fixes issue #2865 by making image size equal to label size (changes only affect German language currently). 
Ban numbering also starts from 1 now for All Draft matches (could not find matches with mode All Pick in recent games)

PC 
![image](https://user-images.githubusercontent.com/71214045/149944154-d99b5713-a576-4253-ba5d-9279ff7dd224.png)
![image](https://user-images.githubusercontent.com/71214045/149944188-a35bd3ea-4dd5-4920-ab8d-70e685344bd5.png)

Mobile
![image](https://user-images.githubusercontent.com/71214045/149945475-1ed8fae7-16c0-42c4-967c-2878c4f77ad9.png)
![image](https://user-images.githubusercontent.com/71214045/149945529-334300b2-a287-402a-a9f2-a4889da8d91a.png)
 