### PR TITLE
Changed item tooltip display to separate multiple hints

### DIFF
--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -235,7 +235,7 @@ const ItemTooltip = ({ item, inflictor }) => (
       }
       return null;
     })}
-    {item.hint && <Hint>{item.hint}</Hint>}
+    {item.hint && item.hint.map((hint) => <Hint>{hint}</Hint>)}
     {item.lore && <Lore>{item.lore}</Lore>}
     {item.components &&
     <Components>

--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -235,7 +235,7 @@ const ItemTooltip = ({ item, inflictor }) => (
       }
       return null;
     })}
-    {item.hint && item.hint.map((hint) => <Hint>{hint}</Hint>)}
+    {item.hint && item.hint?.map((hint) => <Hint>{hint}</Hint>)}
     {item.lore && <Lore>{item.lore}</Lore>}
     {item.components &&
     <Components>


### PR DESCRIPTION
Old :
![image](https://user-images.githubusercontent.com/13117941/167017211-7cdf6984-8d80-4a56-8b60-00b2a6cd60f6.png)

New :
![new](https://user-images.githubusercontent.com/13117941/167017099-fa9a91d4-f302-44f6-b9f0-4f1cf811fca8.jpg)
