### PR TITLE
Fix npm install failing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
With newer versions of npm (>=8.6.0), `npm install` fails with the following error:

``` bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: @material-ui/core@4.8.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR!   peer react@">=16.3.0" from @emotion/core@10.3.1
npm ERR!   node_modules/@emotion/core
npm ERR!     peer @emotion/core@"^10.0.27" from @emotion/styled@10.3.0
npm ERR!     node_modules/@emotion/styled
npm ERR!       @emotion/styled@"^10.0.27" from @storybook/theming@6.4.19
npm ERR!       node_modules/@storybook/theming
npm ERR!         @storybook/theming@"6.4.19" from @storybook/addon-actions@6.4.19
npm ERR!         node_modules/@storybook/addon-actions
npm ERR!         11 more (@storybook/addon-backgrounds, ...)
npm ERR!     peer @emotion/core@"^10.0.28" from @emotion/styled-base@10.3.0
npm ERR!     node_modules/@emotion/styled-base
npm ERR!       @emotion/styled-base@"^10.3.0" from @emotion/styled@10.3.0
npm ERR!       node_modules/@emotion/styled
npm ERR!         @emotion/styled@"^10.0.27" from @storybook/theming@6.4.19
npm ERR!         node_modules/@storybook/theming
npm ERR!     3 more (@storybook/theming, @storybook/ui, emotion-theming)
npm ERR!   61 more (@emotion/styled, @emotion/styled-base, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from @material-ui/core@4.8.0
npm ERR! node_modules/@material-ui/core
npm ERR!   @material-ui/core@"^4.5.0" from the root project
npm ERR!   peer @material-ui/core@"^4.0.0" from @material-ui/icons@4.5.1
npm ERR!   node_modules/@material-ui/icons
npm ERR!     @material-ui/icons@"^4.5.1" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: react@16.14.0
npm ERR! node_modules/react
npm ERR!   peer react@"^16.8.0" from @material-ui/core@4.8.0
npm ERR!   node_modules/@material-ui/core
npm ERR!     @material-ui/core@"^4.5.0" from the root project
npm ERR!     peer @material-ui/core@"^4.0.0" from @material-ui/icons@4.5.1
npm ERR!     node_modules/@material-ui/icons
npm ERR!       @material-ui/icons@"^4.5.1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

This is due to this: https://github.com/npm/cli/issues/4664#issuecomment-1086096726

Fixed by running the command included (`npm config set legacy-peer-deps=true --location=project`)

