### PR TITLE
Fix missing tooltip icons

### DIFF
--- a/src/components/AbilityTooltip/index.jsx
+++ b/src/components/AbilityTooltip/index.jsx
@@ -196,13 +196,13 @@ const AbilityTooltip = ({ ability, inflictor }) => (
     <Resources>
         {ability.mc &&
         <span>
-          <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/mana.png`} alt="" />
+          <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/mana.png`} alt="" />
           <span className="values">{formatValues(ability.mc)}</span>
         </span>
         }
         {ability.cd &&
         <span>
-          <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/cooldown.png`} alt="" />
+          <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/cooldown.png`} alt="" />
           <span className="values">{formatValues(ability.cd)}</span>
         </span>
         }

--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -192,7 +192,7 @@ const ItemTooltip = ({ item, inflictor }) => (
         <img id="item-img" src={`${process.env.REACT_APP_IMAGE_CDN}${item.img}`} alt="" />
         <HeaderText>
           <div>{item.dname}</div>
-          <div id="gold">{item.tier ? "Neutral item" : <><img src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/gold.png`} alt="" />{item.cost}</>}</div>
+          <div id="gold">{item.tier ? "Neutral item" : <><img src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/gold.png`} alt="" />{item.cost}</>}</div>
         </HeaderText>
       </div>
     </Header>
@@ -217,13 +217,13 @@ const ItemTooltip = ({ item, inflictor }) => (
                 <div className="resources">
                   {type === 'active' && item.mc &&
                   <span>
-                    <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/mana.png`} alt="" />
+                    <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/mana.png`} alt="" />
                     <span className="values">{item.mc}</span>
                   </span>
                 }
                   {type === 'active' && item.cd &&
                   <span>
-                    <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/cooldown.png`} alt="" />
+                    <ResourceIcon src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/cooldown.png`} alt="" />
                     <span className="values">{item.cd}</span>
                   </span>
                 }

--- a/src/components/Match/BuildingMap/BuildingMap.jsx
+++ b/src/components/Match/BuildingMap/BuildingMap.jsx
@@ -385,7 +385,7 @@ const BuildingMap = ({ match, strings }) => {
                             </span>
                             :
                             <span>
-                              {type !== 'fort' && <img src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/gold.png`} alt="" />}
+                              {type !== 'fort' && <img src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/gold.png`} alt="" />}
                               {strings.building_lasthit}
                             </span>
                         }

--- a/src/components/Match/Overview/Timeline.jsx
+++ b/src/components/Match/Overview/Timeline.jsx
@@ -504,7 +504,7 @@ const Timeline = ({
                                   <font style={{ color: constants.colorGolden }}>{Math.abs(death.gold_delta)} </font>
                                   <img
                                     alt=""
-                                    src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/gold.png`}
+                                    src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/gold.png`}
                                   />
                                 </span>
                               </section>

--- a/src/components/Match/TeamfightMap/index.jsx
+++ b/src/components/Match/TeamfightMap/index.jsx
@@ -241,7 +241,7 @@ export const TeamfightIcon = ({
 export const GoldDelta = ({ radiantGoldDelta }) => (
   <div className="goldChange">
     {isRadiant(radiantGoldDelta) ? radiantGoldDelta : radiantGoldDelta * -1}
-    <img src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/dota_react/tooltips/gold.png`} alt="" />
+    <img src={`${process.env.REACT_APP_IMAGE_CDN}/apps/dota2/images/tooltips/gold.png`} alt="" />
   </div>
 );
 


### PR DESCRIPTION
This resolves issue https://github.com/odota/web/issues/2964

It turns out that for the steam CDN, the tooltip icons don't contain the `dota_react` token in the path. This lead to the mana, cooldown, and gold tooltip icons to lead to a 404

I'm not sure why this difference exists, I didn't find any documentation on the CDN. So its possible this may need to be reverted if they ever make the paths consistent. But this will make the icons work until then.

Example URLS, both these resolve to the expected icon

Item URL, does contain the `dota_react` token
https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/items/ward_observer.png

Tooltip URL, does not contain it
https://cdn.cloudflare.steamstatic.com/apps/dota2/images/tooltips/mana.png