### PR TITLE
Feature - Aghanim's upgrade tooltip on Hero page

### DIFF
--- a/src/components/AghsTooltip/AghsTooltipBody.jsx
+++ b/src/components/AghsTooltip/AghsTooltipBody.jsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import constants from '../constants';
+import { formatSkillOrAttributeValues } from '../../utility';
+
+const Ability = styled.div`
+  margin-left: 8px;
+  color: rgb(176, 198, 212);
+  max-width: 85%;
+
+  .ability-text {
+    padding: 6px;
+    font-weight: normal;
+    color: rgb(169, 181, 193);
+    text-shadow: 1px 1px black;
+  }
+`;
+
+const AbilityDescription = styled.p`
+  line-height: 16px;
+  color: #c8dade;  
+  margin: 0px;
+  padding: 0px;
+  font-weight: normal;
+`;
+
+const AbilityIcon = styled.img`
+  border-radius: 4px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: 15%;
+  opacity: .7;
+  overflow: hidden;
+  border: 1px black solid;
+  height: 42px;
+  transition: opacity .2s, box-shadow .4s, transform .2s;
+
+  &:hover {
+    opacity: 1;
+    box-shadow: 0 0 150px rgba(255, 255, 255, .4);
+    transform: scale(1.1);
+  }
+`;
+
+const AbilityTitle = styled.span`
+  color: ${constants.textColorPrimary};
+  text-transform: uppercase;
+  font-size: 1rem;
+`;
+
+const Attributes = styled.div`
+  margin-top: 4px;
+  line-height: 16px;
+  
+  & #footer {
+    color: #95a5a6;
+  }
+
+  & #value {
+    font-weight: 500;
+  }
+
+  & #header{
+    color: #95a5a6; 
+  }
+`;
+
+const Body = styled.div`
+display: flex;
+margin: 10px 9px 10px 9px;
+padding: 6px;
+font-weight: bold;
+color: ${constants.colorBlueGray};
+`;
+
+const Break = styled.div`
+  margin-left: 13px;
+  margin-right: 13px;
+  height: 1px;
+  background-color: #080D15;
+`;
+
+const NewAbility = styled.div`
+  background-color: #335380;
+  text-transform: uppercase;
+  color: ${constants.textColorPrimary};
+  text-align: center;
+  font-size: 10px;
+  padding: 0px 6px;
+  width: 40%;
+  margin: 4px 0px;
+`;
+
+const getAghsAttributes = (skillObject) => {
+  const skills = (skillObject.attrib || [])
+  const attributes = skills.map(attrib => (
+    <div className="attribute" key={attrib.key}>
+      <span id="header">{attrib.header} </span>
+      <span id="value">{formatSkillOrAttributeValues(attrib.value)}</span>
+      <span id="footer"> {attrib.footer || ''}</span>
+    </div>
+  ))
+  return (
+    <>
+      {attributes}
+      {skillObject.dmg ? <div className="attribute">DAMAGE: <span id="value">{formatSkillOrAttributeValues(skillObject.dmg)}</span></div> : ''}
+    </>
+  )
+}
+
+const AghsTooltipBody = ({ icon, skillName, isNewSkill, aghsDescription, skillObject, hasUpgrade }) => (
+  <Body>
+    {hasUpgrade ? (
+      <>
+        <AbilityIcon src={icon} />
+        <Ability>
+          <AbilityTitle>
+            {skillName}
+          </AbilityTitle>
+          <NewAbility>
+            {isNewSkill ? (<span>New ability</span>) : (<span>Upgrade</span>)}
+          </NewAbility>
+          <AbilityDescription>
+            {aghsDescription}
+            {skillObject.attrib && skillObject.attrib.length > 0 &&
+              <div>
+                <Break />
+                <Attributes>
+                  {getAghsAttributes(skillObject)}
+                </Attributes>
+              </div>
+            }
+          </AbilityDescription>
+        </Ability>
+      </>
+    ) : (
+      <span>No Aghanim&apos;s upgrade found</span>
+    )}
+
+  </Body>
+)
+
+AghsTooltipBody.propTypes = {
+  icon: PropTypes.string,
+  skillName: PropTypes.string,
+  isNewSkill: PropTypes.bool,
+  aghsDescription: PropTypes.string,
+  skillObject: PropTypes.shape({}),
+  hasUpgrade: PropTypes.bool,
+}
+
+export default AghsTooltipBody;

--- a/src/components/AghsTooltip/AghsTooltipHeader.jsx
+++ b/src/components/AghsTooltip/AghsTooltipHeader.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import constants from '../constants';
+
+const Header = styled.div`
+  font-size: ${constants.fontSizeCommon};
+  color: ${constants.colorBlue};
+  background-color: rgba(102, 187, 255, 0.2);
+  
+  .header-content {
+    height: 25px;
+    padding: 5px 13px 5px 13px;
+    white-space: nowrap;
+    display: flex;
+  }
+
+  #scepter-img {
+    display: inline-block;
+    height: 32px;
+    width: 30px;
+    padding: 4px;
+    margin: -8px 6px 0px 6px;
+    vertical-align: middle;
+  } 
+
+  #shard-img {
+    display: inline-block;
+    height: 25px;
+    width: 35px;
+    margin: 2px 4px;
+    padding: 0 4px;
+    vertical-align: middle;
+  } 
+`;
+
+const HeaderText = styled.div`
+  height: 100%;
+  position: relative;
+  display: inline-block;
+  margin-left: 8px;
+  color: ${constants.colorBlue};
+  font-weight: bold;
+  letter-spacing: 1px;
+`;
+
+const AghanimsTooltipHeader = ({ image, type, children }) => (
+  <Header>
+    <div className="header-content">
+      <img id={`${type}-img`} src={image} alt="" />
+      <HeaderText>
+        {children}
+      </HeaderText>
+    </div>
+  </Header>
+);
+
+AghanimsTooltipHeader.propTypes = {
+  image: PropTypes.string,
+  type: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
+}
+
+export default AghanimsTooltipHeader;

--- a/src/components/AghsTooltip/index.jsx
+++ b/src/components/AghsTooltip/index.jsx
@@ -24,23 +24,20 @@ const Header = styled.div`
   }
 
   #scepter-img {
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 15%; 
     display: inline-block;
-    height: 100%;
+    height: 32px;
+    width: 35px;
+    padding: 4px;
+    margin-top: -8px;
     vertical-align: middle;
-    width: auto;
   } 
 
   #shard-img {
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 15%; 
     display: inline-block;
-    height: 100%;
+    height: 25px;
+    width: 35px;
+    padding: 0 4px;
     vertical-align: middle;
-    width: auto;
   } 
 `;
 
@@ -180,11 +177,13 @@ const ItemTooltip = ({ upgrades, skills }) => {
   let newScepterAbility = null;
   let newShardAbility = null;
 
+  console.log("talal", skills);
+
   function getAbilityImage(skillName) {
     const ability = skills.find(skill =>
       skill.data.dname === skillName
     )
-    return ability.data.img
+    return ability.data.img // TODO: Null or not found check maybe
   }
 
   if (upgrades.has_shard) {

--- a/src/components/AghsTooltip/index.jsx
+++ b/src/components/AghsTooltip/index.jsx
@@ -135,6 +135,7 @@ const AbilityIcon = styled.img`
   flex-basis: 15%;
   opacity: .7;
   overflow: hidden;
+  border: 1px black solid;
   height: 35px;
   transition: opacity .2s, box-shadow .4s, transform .2s;
 
@@ -327,7 +328,7 @@ align-items: center;
 const AghsTooltip = ({ upgrades, skills }) => (
   <TtWrapper>
     <StyledAghanimsBuffs>
-      <ReactTooltip id="aghanim" effect="solid" place="bottom">
+      <ReactTooltip id="aghanim" effect="solid" place="bottom" >
         <ItemTooltip type="scepter" upgrades={upgrades} skills={skills} />
       </ReactTooltip>
     </StyledAghanimsBuffs>

--- a/src/components/AghsTooltip/index.jsx
+++ b/src/components/AghsTooltip/index.jsx
@@ -1,168 +1,16 @@
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 import ReactTooltip from 'react-tooltip';
+import PropTypes from 'prop-types';
 import constants from '../constants';
-
+import AghanimsTooltipHeader from './AghsTooltipHeader';
+import AghsTooltipBody from './AghsTooltipBody';
 
 const Wrapper = styled.div`
-  width: 300px;
+  width: 340px;
   background: rgb(21, 27, 29);
   overflow: hidden;
   border: 2px solid #27292b;
-`;
-
-const Header = styled.div`
-  font-size: ${constants.fontSizeCommon};
-  color: ${constants.colorBlue};
-  background-color: rgba(102, 187, 255, 0.2);
-  
-  .header-content {
-    height: 25px;
-    padding: 5px 13px 5px 13px;
-    white-space: nowrap;
-    display: flex;
-  }
-
-  #scepter-img {
-    display: inline-block;
-    height: 32px;
-    width: 35px;
-    padding: 4px;
-    margin-top: -8px;
-    vertical-align: middle;
-  } 
-
-  #shard-img {
-    display: inline-block;
-    height: 25px;
-    width: 35px;
-    padding: 0 4px;
-    vertical-align: middle;
-  } 
-`;
-
-const HeaderText = styled.div`
-  height: 100%;
-  position: relative;
-  display: inline-block;
-  margin-left: 8px;
-  color: ${constants.colorBlue};
-  font-weight: bold;
-  letter-spacing: 1px;
-
-  & div {
-    width: 200px;
-    padding-bottom: 5px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  & #gold {
-    color: ${constants.colorGolden};
-    font-weight: normal;
-
-    & img {
-      height: 13px;
-      margin-right: 5px;
-      position: relative;
-      top: 2px;
-    }
-  }
-`;
-
-const NewAbility = styled.div`
-  background-color: #335380;
-  text-transform: uppercase;
-  color: ${constants.textColorPrimary};
-  text-align: center;
-  font-size: 10px;
-  padding: 0px 6px;
-  width: 40%;
-  margin: 4px 0px;
-`;
-
-const Attributes = styled.div`
-  margin-top: 4px;
-  line-height: 16px;
-  
-  & #footer {
-    color: #95a5a6;
-  }
-
-  & #value {
-    font-weight: 500;
-  }
-
-  & #header{
-    color: #95a5a6; 
-  }
-`;
-
-const Body = styled.div`
-  display: flex;
-
-  & .ability-icon {
-
-  }
-
-  & .ability-title {
-
-  }
-
-  margin: 10px 9px 10px 9px;
-  padding: 6px;
-  font-weight: bold;
-  color: ${constants.colorBlueGray};
-`;
-
-const Ability = styled.div`
-  margin-left: 8px;
-  color: rgb(176, 198, 212);
-
-  .ability-text {
-    padding: 6px;
-    font-weight: normal;
-    color: rgb(169, 181, 193);
-    text-shadow: 1px 1px black;
-  }
-`;
-
-const AbilityIcon = styled.img`
-  border-radius: 4px;
-  flex-grow: 0;
-  flex-shrink: 0;
-  flex-basis: 15%;
-  opacity: .7;
-  overflow: hidden;
-  border: 1px black solid;
-  height: 35px;
-  transition: opacity .2s, box-shadow .4s, transform .2s;
-
-  &:hover {
-    opacity: 1;
-    box-shadow: 0 0 150px rgba(255, 255, 255, .4);
-    transform: scale(1.1);
-  }
-`;
-const Break = styled.div`
-    margin-left: 13px;
-    margin-right: 13px;
-    height: 1px;
-    background-color: #080D15;
-`;
-const AbilityTitle = styled.span`
-  color: ${constants.textColorPrimary};
-  text-transform: uppercase;
-  font-size: 1rem;
-`;
-
-const AbilityDescription = styled.p`
-  line-height: 16px;
-  color: #c8dade;  
-  margin: 0px;
-  padding: 0px;
-  font-weight: normal;
 `;
 
 const CombinedWrapper = styled.div`
@@ -171,130 +19,58 @@ const CombinedWrapper = styled.div`
   flex-direction: column;
   gap: 10px;
   margin: 0 -20px;
-`
-  ;
+`;
 
-const ItemTooltip = ({ upgrades, skills }) => {
+const AghanimsToolTip = ({ upgrades, skills }) => {
   let newScepterAbility = null;
   let newShardAbility = null;
 
-  console.log("talal", skills);
-
-  function getAbilityImage(skillName) {
+  const getAghsSkillObject = (skillName) => {
+    if(!skillName || skillName === "") return null;
     const ability = skills.find(skill =>
       skill.data.dname === skillName
     )
-    return ability.data.img // TODO: Null or not found check maybe
+    return ability.data;
   }
 
-  if (upgrades.has_shard) {
+  if (skills && upgrades) {
     const newShardSkillName = upgrades.shard_skill_name;
-    const newShardSkillObject = skills.find(skill =>
-      skill.data.dname === newShardSkillName
-    ).data;
+    const newShardSkillObject = getAghsSkillObject(newShardSkillName)
     newShardAbility = (
       <Wrapper>
-        <Header>
-          <div className="header-content">    
-            <img id="shard-img" src="/assets/images/dota2/shard_0.png" alt="" />
-            <HeaderText>
-              <div>Aghanim&lsquo;s Shard</div>
-            </HeaderText>
-          </div>
-        </Header>
-        <Body>
-          <AbilityIcon src={`${process.env.REACT_APP_IMAGE_CDN}${getAbilityImage(upgrades.shard_skill_name)}`} />
-          <Ability>
-            <AbilityTitle>
-              {upgrades.shard_skill_name}
-            </AbilityTitle>
-            <NewAbility>
-              {upgrades.shard_new_skill ? (<span>New ability</span>) : (<span>Upgrade</span>)}
-            </NewAbility>
-            <AbilityDescription>
-              {upgrades.shard_desc}
-              {newShardSkillObject.attrib && newShardSkillObject.attrib.length > 0 &&
-                <div>
-                  <Break />
-                  <Attributes>
-                    <div>
-                      {(newShardSkillObject.attrib || []).map(attrib => (
-                        <div className="attribute" key={attrib.key}>
-                          <span id="header">{attrib.header} </span>
-                          <span id="value">{formatValues(attrib.value)}</span>
-                          <span id="footer"> {attrib.footer || ''}</span>
-                        </div>))}
-                      {newShardSkillObject.dmg ? <div className="attribute">DAMAGE: <span id="value">{formatValues(newShardSkillObject.dmg)}</span></div> : ''}
-                    </div>
-                  </Attributes>
-                </div>
-              }
-            </AbilityDescription>
-          </Ability>
-        </Body>
+        <AghanimsTooltipHeader image="/assets/images/dota2/shard_0.png" type="shard">
+          <span>Aghanim&lsquo;s Shard</span>
+        </AghanimsTooltipHeader>
+        <AghsTooltipBody
+          icon={`${process.env.REACT_APP_IMAGE_CDN}${newShardSkillObject ? newShardSkillObject.img : ""}`}
+          skillName={upgrades.shard_skill_name}
+          hasUpgrade={upgrades.has_shard}
+          isNewSkill={upgrades.shard_new_skill}
+          aghsDescription={upgrades.shard_desc}
+          skillObject={newShardSkillObject}
+        />
       </Wrapper>
     )
-  } else {
-    newShardAbility = (<div>There is no new ability for this hero :(</div>)
-  }
 
-  function formatValues(values) {
-    if (Array.isArray(values)) {
-      return values.filter(value => value).join(' / ');
-    }
-    return values;
-  }
-
-  if (upgrades.has_scepter) {
     const newScepterSkillName = upgrades.scepter_skill_name;
-    const newScepterSkillObject = skills.find(skill =>
-      skill.data.dname === newScepterSkillName
-    ).data;
+    const newScepterSkillObject = getAghsSkillObject(newScepterSkillName);
     newScepterAbility = (
       <Wrapper>
-        <Header>
-          <div className="header-content">
-            <img id="scepter-img" src="/assets/images/dota2/scepter_0.png" alt="" />
-            <HeaderText>
-              <div>Aghanim&lsquo;s Scepter</div>
-            </HeaderText>
-          </div>
-        </Header>
-        <Body>
-          <AbilityIcon src={`${process.env.REACT_APP_IMAGE_CDN}${getAbilityImage(upgrades.scepter_skill_name)}`} />
-          <Ability>
-            <AbilityTitle>
-              {upgrades.scepter_skill_name}
-            </AbilityTitle>
-            <NewAbility>
-              {upgrades.scepter_new_skill ? (<span>New ability</span>) : (<span>Upgrade</span>)}
-            </NewAbility>
-            <AbilityDescription>
-              {upgrades.scepter_desc}
-              {newScepterSkillObject.attrib && newScepterSkillObject.attrib.length > 0 &&
-                <div>
-                  <Break />
-                  <Attributes>
-                    <div>
-                      {(newScepterSkillObject.attrib || []).map(attrib => (
-                        <div className="attribute" key={attrib.key}>
-                          <span id="header">{attrib.header} </span>
-                          <span id="value">{formatValues(attrib.value)}</span>
-                          <span id="footer"> {attrib.footer || ''}</span>
-                        </div>))}
-                      {newScepterSkillObject.dmg ? <div className="attribute">DAMAGE: <span id="value">{formatValues(newScepterSkillObject.dmg)}</span></div> : ''}
-                    </div>
-                  </Attributes>
-                </div>
-              }
-            </AbilityDescription>
-          </Ability>
-        </Body>
+        <AghanimsTooltipHeader image="/assets/images/dota2/scepter_0.png" type="scepter">
+          <span>Aghanim&lsquo;s Scepter</span>
+        </AghanimsTooltipHeader>
+        <AghsTooltipBody
+          icon={`${process.env.REACT_APP_IMAGE_CDN}${newScepterSkillObject ? newScepterSkillObject.img : ""}`}
+          skillName={upgrades.scepter_skill_name}
+          hasUpgrade={upgrades.has_scepter}
+          isNewSkill={upgrades.scepter_new_skill}
+          aghsDescription={upgrades.scepter_desc}
+          skillObject={newScepterSkillObject}
+        />
       </Wrapper>
     )
-  } else {
-    newScepterAbility = (<div>No Aghanim&lsquo;s upgrade found</div>)
   }
+
   return (
     <CombinedWrapper>
       {newScepterAbility}
@@ -325,14 +101,19 @@ align-items: center;
   padding: 0px !important;
 }
 `
-const AghsTooltip = ({ upgrades, skills }) => (
+const AghsTooltipWrapper = ({ upgrades, skills }) => (
   <TtWrapper>
     <StyledAghanimsBuffs>
       <ReactTooltip id="aghanim" effect="solid" place="bottom" >
-        <ItemTooltip type="scepter" upgrades={upgrades} skills={skills} />
+        <AghanimsToolTip type="scepter" upgrades={upgrades} skills={skills} />
       </ReactTooltip>
     </StyledAghanimsBuffs>
   </TtWrapper>
 );
 
-export default AghsTooltip;
+AghsTooltipWrapper.propTypes = {
+  upgrades:  PropTypes.shape({}).isRequired,
+  skills: PropTypes.array.isRequired,
+}
+
+export default AghsTooltipWrapper;

--- a/src/components/AghsTooltip/index.jsx
+++ b/src/components/AghsTooltip/index.jsx
@@ -1,0 +1,338 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+import ReactTooltip from 'react-tooltip';
+import constants from '../constants';
+
+
+const Wrapper = styled.div`
+  width: 300px;
+  background: rgb(21, 27, 29);
+  overflow: hidden;
+  border: 2px solid #27292b;
+`;
+
+const Header = styled.div`
+  font-size: ${constants.fontSizeCommon};
+  color: ${constants.colorBlue};
+  background-color: rgba(102, 187, 255, 0.2);
+  
+  .header-content {
+    height: 25px;
+    padding: 5px 13px 5px 13px;
+    white-space: nowrap;
+    display: flex;
+  }
+
+  #scepter-img {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: 15%; 
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    width: auto;
+  } 
+
+  #shard-img {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: 15%; 
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    width: auto;
+  } 
+`;
+
+const HeaderText = styled.div`
+  height: 100%;
+  position: relative;
+  display: inline-block;
+  margin-left: 8px;
+  color: ${constants.colorBlue};
+  font-weight: bold;
+  letter-spacing: 1px;
+
+  & div {
+    width: 200px;
+    padding-bottom: 5px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  & #gold {
+    color: ${constants.colorGolden};
+    font-weight: normal;
+
+    & img {
+      height: 13px;
+      margin-right: 5px;
+      position: relative;
+      top: 2px;
+    }
+  }
+`;
+
+const NewAbility = styled.div`
+  background-color: #335380;
+  text-transform: uppercase;
+  color: ${constants.textColorPrimary};
+  text-align: center;
+  font-size: 10px;
+  padding: 0px 6px;
+  width: 40%;
+  margin: 4px 0px;
+`;
+
+const Attributes = styled.div`
+  margin-top: 4px;
+  line-height: 16px;
+  
+  & #footer {
+    color: #95a5a6;
+  }
+
+  & #value {
+    font-weight: 500;
+  }
+
+  & #header{
+    color: #95a5a6; 
+  }
+`;
+
+const Body = styled.div`
+  display: flex;
+
+  & .ability-icon {
+
+  }
+
+  & .ability-title {
+
+  }
+
+  margin: 10px 9px 10px 9px;
+  padding: 6px;
+  font-weight: bold;
+  color: ${constants.colorBlueGray};
+`;
+
+const Ability = styled.div`
+  margin-left: 8px;
+  color: rgb(176, 198, 212);
+
+  .ability-text {
+    padding: 6px;
+    font-weight: normal;
+    color: rgb(169, 181, 193);
+    text-shadow: 1px 1px black;
+  }
+`;
+
+const AbilityIcon = styled.img`
+  border-radius: 4px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: 15%;
+  opacity: .7;
+  overflow: hidden;
+  height: 35px;
+  transition: opacity .2s, box-shadow .4s, transform .2s;
+
+  &:hover {
+    opacity: 1;
+    box-shadow: 0 0 150px rgba(255, 255, 255, .4);
+    transform: scale(1.1);
+  }
+`;
+const Break = styled.div`
+    margin-left: 13px;
+    margin-right: 13px;
+    height: 1px;
+    background-color: #080D15;
+`;
+const AbilityTitle = styled.span`
+  color: ${constants.textColorPrimary};
+  text-transform: uppercase;
+  font-size: 1rem;
+`;
+
+const AbilityDescription = styled.p`
+  line-height: 16px;
+  color: #c8dade;  
+  margin: 0px;
+  padding: 0px;
+  font-weight: normal;
+`;
+
+const CombinedWrapper = styled.div`
+  display: flex;
+  background-color: rgba(0,0,255,0.01);
+  flex-direction: column;
+  gap: 10px;
+  margin: 0 -20px;
+`
+  ;
+
+const ItemTooltip = ({ upgrades, skills }) => {
+  let newScepterAbility = null;
+  let newShardAbility = null;
+
+  function getAbilityImage(skillName) {
+    const ability = skills.find(skill =>
+      skill.data.dname === skillName
+    )
+    return ability.data.img
+  }
+
+  if (upgrades.has_shard) {
+    const newShardSkillName = upgrades.shard_skill_name;
+    const newShardSkillObject = skills.find(skill =>
+      skill.data.dname === newShardSkillName
+    ).data;
+    newShardAbility = (
+      <Wrapper>
+        <Header>
+          <div className="header-content">    
+            <img id="shard-img" src="/assets/images/dota2/shard_0.png" alt="" />
+            <HeaderText>
+              <div>Aghanim&lsquo;s Shard</div>
+            </HeaderText>
+          </div>
+        </Header>
+        <Body>
+          <AbilityIcon src={`${process.env.REACT_APP_IMAGE_CDN}${getAbilityImage(upgrades.shard_skill_name)}`} />
+          <Ability>
+            <AbilityTitle>
+              {upgrades.shard_skill_name}
+            </AbilityTitle>
+            <NewAbility>
+              {upgrades.shard_new_skill ? (<span>New ability</span>) : (<span>Upgrade</span>)}
+            </NewAbility>
+            <AbilityDescription>
+              {upgrades.shard_desc}
+              {newShardSkillObject.attrib && newShardSkillObject.attrib.length > 0 &&
+                <div>
+                  <Break />
+                  <Attributes>
+                    <div>
+                      {(newShardSkillObject.attrib || []).map(attrib => (
+                        <div className="attribute" key={attrib.key}>
+                          <span id="header">{attrib.header} </span>
+                          <span id="value">{formatValues(attrib.value)}</span>
+                          <span id="footer"> {attrib.footer || ''}</span>
+                        </div>))}
+                      {newShardSkillObject.dmg ? <div className="attribute">DAMAGE: <span id="value">{formatValues(newShardSkillObject.dmg)}</span></div> : ''}
+                    </div>
+                  </Attributes>
+                </div>
+              }
+            </AbilityDescription>
+          </Ability>
+        </Body>
+      </Wrapper>
+    )
+  } else {
+    newShardAbility = (<div>There is no new ability for this hero :(</div>)
+  }
+
+  function formatValues(values) {
+    if (Array.isArray(values)) {
+      return values.filter(value => value).join(' / ');
+    }
+    return values;
+  }
+
+  if (upgrades.has_scepter) {
+    const newScepterSkillName = upgrades.scepter_skill_name;
+    const newScepterSkillObject = skills.find(skill =>
+      skill.data.dname === newScepterSkillName
+    ).data;
+    newScepterAbility = (
+      <Wrapper>
+        <Header>
+          <div className="header-content">
+            <img id="scepter-img" src="/assets/images/dota2/scepter_0.png" alt="" />
+            <HeaderText>
+              <div>Aghanim&lsquo;s Scepter</div>
+            </HeaderText>
+          </div>
+        </Header>
+        <Body>
+          <AbilityIcon src={`${process.env.REACT_APP_IMAGE_CDN}${getAbilityImage(upgrades.scepter_skill_name)}`} />
+          <Ability>
+            <AbilityTitle>
+              {upgrades.scepter_skill_name}
+            </AbilityTitle>
+            <NewAbility>
+              {upgrades.scepter_new_skill ? (<span>New ability</span>) : (<span>Upgrade</span>)}
+            </NewAbility>
+            <AbilityDescription>
+              {upgrades.scepter_desc}
+              {newScepterSkillObject.attrib && newScepterSkillObject.attrib.length > 0 &&
+                <div>
+                  <Break />
+                  <Attributes>
+                    <div>
+                      {(newScepterSkillObject.attrib || []).map(attrib => (
+                        <div className="attribute" key={attrib.key}>
+                          <span id="header">{attrib.header} </span>
+                          <span id="value">{formatValues(attrib.value)}</span>
+                          <span id="footer"> {attrib.footer || ''}</span>
+                        </div>))}
+                      {newScepterSkillObject.dmg ? <div className="attribute">DAMAGE: <span id="value">{formatValues(newScepterSkillObject.dmg)}</span></div> : ''}
+                    </div>
+                  </Attributes>
+                </div>
+              }
+            </AbilityDescription>
+          </Ability>
+        </Body>
+      </Wrapper>
+    )
+  } else {
+    newScepterAbility = (<div>No Aghanim&lsquo;s upgrade found</div>)
+  }
+  return (
+    <CombinedWrapper>
+      {newScepterAbility}
+      {newShardAbility}
+    </CombinedWrapper>
+  )
+}
+
+const TtWrapper = styled.div`
+  background: linear-gradient(to bottom, ${constants.colorBlueMuted}, ${constants.primarySurfaceColor});
+  border-radius: 4px;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, .3);
+  position: relative;
+`;
+
+export const StyledAghanimsBuffs = styled.div`
+display: flex;
+flex-direction: column;
+justify-content: center;
+align-items: center;
+
+> img {
+  width: 65%;
+}
+
+.__react_component_tooltip {
+  opacity: 1 !important;
+  padding: 0px !important;
+}
+`
+const AghsTooltip = ({ upgrades, skills }) => (
+  <TtWrapper>
+    <StyledAghanimsBuffs>
+      <ReactTooltip id="aghanim" effect="solid" place="bottom">
+        <ItemTooltip type="scepter" upgrades={upgrades} skills={skills} />
+      </ReactTooltip>
+    </StyledAghanimsBuffs>
+  </TtWrapper>
+);
+
+export default AghsTooltip;

--- a/src/components/Hero/Abilities.jsx
+++ b/src/components/Hero/Abilities.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import propTypes from 'prop-types';
 import Ability from './Ability';
 import Talents from './Talents';
+import AghanimUpgrades from './AghanimUpgrades';
 
 const Wrapper = styled.div`
   align-items: center;
@@ -59,15 +60,18 @@ const Abilities = ({ hero, abilities, heroAbilities }) => {
 
     const heroNpcName = toMapHeroAbsTals.name;
     const heroAbs = heroAbilities[heroNpcName];
+    console.log('heroAbs', heroAbs.abilities)
 
     // Filter out generic_hidden skills from skill list
     heroAbs.abilities = filterAbilities(heroAbs.abilities);
     talsMap.skills = mapAbilities(heroAbs.abilities);
 
+    console.log('talsmap', talsMap.skills)
+
     // Map Talents and assign them to correct level in Object
     const heroTalents = mapTalents(heroAbs.talents);
     talsMap.talents = mapTalentsToLevel(heroTalents);
-
+    
     return talsMap;
   };
 
@@ -75,9 +79,12 @@ const Abilities = ({ hero, abilities, heroAbilities }) => {
 
   return (
     <Wrapper>
-      {renderAbilities(heroAbs.skills)}
       <AbilityItem>
         <Talents talents={heroAbs.talents} />
+      </AbilityItem>
+      {renderAbilities(heroAbs.skills)}
+      <AbilityItem>
+        <AghanimUpgrades heroName={hero.name} skills={heroAbs.skills} />
       </AbilityItem>
     </Wrapper>
   );

--- a/src/components/Hero/Abilities.jsx
+++ b/src/components/Hero/Abilities.jsx
@@ -60,13 +60,10 @@ const Abilities = ({ hero, abilities, heroAbilities }) => {
 
     const heroNpcName = toMapHeroAbsTals.name;
     const heroAbs = heroAbilities[heroNpcName];
-    console.log('heroAbs', heroAbs.abilities)
 
     // Filter out generic_hidden skills from skill list
     heroAbs.abilities = filterAbilities(heroAbs.abilities);
     talsMap.skills = mapAbilities(heroAbs.abilities);
-
-    console.log('talsmap', talsMap.skills)
 
     // Map Talents and assign them to correct level in Object
     const heroTalents = mapTalents(heroAbs.talents);

--- a/src/components/Hero/Abilities.jsx
+++ b/src/components/Hero/Abilities.jsx
@@ -68,7 +68,6 @@ const Abilities = ({ hero, abilities, heroAbilities }) => {
     // Map Talents and assign them to correct level in Object
     const heroTalents = mapTalents(heroAbs.talents);
     talsMap.talents = mapTalentsToLevel(heroTalents);
-    
     return talsMap;
   };
 

--- a/src/components/Hero/Ability.jsx
+++ b/src/components/Hero/Ability.jsx
@@ -52,8 +52,6 @@ const Ability = (props) => {
   const ttId = nanoid();
   const showMana = (props.mc && parseInt(props.mc, 0) > 0);
   let manaString = false;
-  console.log('propsaa', props);
-
   if (showMana) {
     manaString = ((typeof props.mc === 'object') ? props.mc[0] : props.mc);
   }

--- a/src/components/Hero/Ability.jsx
+++ b/src/components/Hero/Ability.jsx
@@ -52,7 +52,7 @@ const Ability = (props) => {
   const ttId = nanoid();
   const showMana = (props.mc && parseInt(props.mc, 0) > 0);
   let manaString = false;
-  
+
   if (showMana) {
     manaString = ((typeof props.mc === 'object') ? props.mc[0] : props.mc);
   }

--- a/src/components/Hero/Ability.jsx
+++ b/src/components/Hero/Ability.jsx
@@ -52,6 +52,7 @@ const Ability = (props) => {
   const ttId = nanoid();
   const showMana = (props.mc && parseInt(props.mc, 0) > 0);
   let manaString = false;
+  
   if (showMana) {
     manaString = ((typeof props.mc === 'object') ? props.mc[0] : props.mc);
   }

--- a/src/components/Hero/Ability.jsx
+++ b/src/components/Hero/Ability.jsx
@@ -52,6 +52,7 @@ const Ability = (props) => {
   const ttId = nanoid();
   const showMana = (props.mc && parseInt(props.mc, 0) > 0);
   let manaString = false;
+  console.log('propsaa', props);
 
   if (showMana) {
     manaString = ((typeof props.mc === 'object') ? props.mc[0] : props.mc);

--- a/src/components/Hero/AghanimUpgrades.jsx
+++ b/src/components/Hero/AghanimUpgrades.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import aghsDesc from 'dotaconstants/build/aghs_desc.json';
 import propTypes from 'prop-types';
-
 import AghsTooltip from '../AghsTooltip';
 import constants from '../constants';
 
@@ -56,7 +55,8 @@ const AghanimUpgrades = ({ heroName, skills }) => (
 );
 
 AghanimUpgrades.propTypes = {
-  heroName: propTypes.string.isRequired,
+  heroName: propTypes.string,
+  skills: propTypes.shape({}),
 };
 
 export default AghanimUpgrades;

--- a/src/components/Hero/AghanimUpgrades.jsx
+++ b/src/components/Hero/AghanimUpgrades.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import aghsDesc from 'dotaconstants/build/aghs_desc.json';
+import propTypes from 'prop-types';
+
+import AghsTooltip from '../AghsTooltip';
+import constants from '../constants';
+
+const Wrapper = styled.div`
+  background: linear-gradient(to bottom, ${constants.colorBlueMuted}, ${constants.primarySurfaceColor});
+  border-radius: 4px;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, .3);
+  position: relative;
+`;
+
+export const StyledAghanimsBuffs = styled.div`
+display: flex;
+flex-direction: column;
+justify-content: center;
+align-items: center;
+
+.__react_component_tooltip {
+  opacity: 1 !important;
+  padding: 0px !important;
+}
+`
+
+export const Icon = styled.img`
+  width: 60%;
+
+  &:hover {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+`;
+
+const getAghsUpgrades = (heroName) => {
+  const hero = (aghsDesc.filter(a => a.hero_name === heroName))[0];
+  return hero || {};
+}
+
+const AghanimUpgrades = ({ heroName, skills }) => (
+  <Wrapper>
+    <AghsTooltip heroName={heroName} upgrades={getAghsUpgrades(heroName)} skills={skills} />
+    <StyledAghanimsBuffs data-for="aghanim" data-tip="aghanim">
+      <Icon
+        src="/assets/images/dota2/scepter_0.png"
+        alt=""
+      />
+      <Icon
+        src="/assets/images/dota2/shard_0.png"
+        alt=""
+      />
+    </StyledAghanimsBuffs>
+  </Wrapper>
+);
+
+AghanimUpgrades.propTypes = {
+  heroName: propTypes.string.isRequired,
+};
+
+export default AghanimUpgrades;

--- a/src/components/Hero/AghanimUpgrades.jsx
+++ b/src/components/Hero/AghanimUpgrades.jsx
@@ -11,6 +11,7 @@ const Wrapper = styled.div`
   border-radius: 4px;
   box-shadow: 0 2px 2px rgba(0, 0, 0, .3);
   position: relative;
+  width: 106%;
 `;
 
 export const StyledAghanimsBuffs = styled.div`
@@ -27,7 +28,6 @@ align-items: center;
 
 export const Icon = styled.img`
   width: 60%;
-
   &:hover {
     opacity: 1;
     transform: scale(1.1);

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -69,6 +69,13 @@ export function formatSeconds(input) {
   return null;
 }
 
+export function formatSkillOrAttributeValues(values) {
+  if (Array.isArray(values)) {
+    return values.filter(value => value).join(' / ');
+  }
+  return values;
+}
+
 export function getLevelFromXp(xp) {
   for (let i = 0; i < xpLevel.length; i += 1) {
     if (xpLevel[i] > xp) {


### PR DESCRIPTION
Add functionality to be able to view a hero's Aghanim's scepter and shard upgrades on the Hero page. Uses the file  `dotaconstants/build/aghs_desc.json` to get its data.

P.S. Also restructures the talents and abilities components on the page to make room for Aghs and mimic in-game positioning.

![image](https://user-images.githubusercontent.com/32406853/187009113-26020aad-899b-47cf-9ca2-91f5610095b5.png)

