### PR TITLE
fix(event-match): fix towers and barracks statuses parsing

### DIFF
--- a/src/components/Match/BuildingMap/BuildingMap.jsx
+++ b/src/components/Match/BuildingMap/BuildingMap.jsx
@@ -259,10 +259,10 @@ const buildingsHealth = {
 const BuildingMap = ({ match, strings }) => {
   if (match && match.tower_status_radiant !== undefined) {
     // see https://wiki.teamfortress.com/wiki/WebAPI/GetMatchDetails
-    let bits = pad(match.tower_status_radiant.toString(2), 11);
-    bits += pad(match.barracks_status_radiant.toString(2), 6);
-    bits += pad(match.tower_status_dire.toString(2), 11);
-    bits += pad(match.barracks_status_dire.toString(2), 6);
+    let bits = pad(match.tower_status_radiant.toString(2), 16).slice(5);
+    bits += pad(match.barracks_status_radiant.toString(2), 8).slice(2);
+    bits += pad(match.tower_status_dire.toString(2), 16).slice(5);
+    bits += pad(match.barracks_status_dire.toString(2), 8).slice(2);
     bits += match.radiant_win ? '10' : '01';
     const icons = [];
     // concat, iterate through bits of all four status values


### PR DESCRIPTION
Fixes #2880

### Description
https://wiki.teamfortress.com/wiki/WebAPI/GetMatchDetails states that Tower Status is a 16-bit unsigned integer and Barracks Status is a 8-bit unsigned integer.
It also states that the first 5 bits of the Tower status are unused and the same goes for the first 2 bits of Barracks Status.

The code meanwhile was assuming that these bits will always be unused
https://github.com/odota/web/blob/283309c2bae23027d32305f4971bf8f8374b04be/src/components/Match/BuildingMap/BuildingMap.jsx#L262-L265

In the case of this event match that was causing the issue the barracks_status_radiant was `11111111` (the full 8-bits), so when passed to the `pad` function which pads to 6, there was nothing to do and the `pad` function was returning the an 8 character string (as expected because 8 > 6).

What we end up with is bits.length = 38:
    11 tower_status_radiant + 8 barracks_status_radiant + 11 tower_status_dire + 6 barracks_status_dire + 2 match_win

buildingData on the other hand is only 36 items long so this will obviously fail
https://github.com/odota/web/blob/283309c2bae23027d32305f4971bf8f8374b04be/src/components/Match/BuildingMap/BuildingMap.jsx#L272-L273

### Changes
This PR fixes the issue by padding to full bit length specified by the docs 16 for Tower Status and 8 for Barracks Status and then remove the unused bits.

#### Note
#2882 missed the issue as there was no problem with the padding function, opened this PR instead as work seemed stale there.