### PR TITLE
Update quickstart instructions for cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenDota Web UI: A web interface for viewing Dota 2 data. This utilizes the [Ope
 
 ## Quickstart
 
-- Clone the repo using `git clone git://github.com/odota/web`
+- Clone the repo using `git clone git@github.com:odota/web.git`
 
 ### With Docker
 


### PR DESCRIPTION
`git clone git://` is deprecated, I ran into this error when trying to use the quickstart code as-is:

<img width="534" alt="Screen Shot 2023-01-18 at 9 35 18 PM" src="https://user-images.githubusercontent.com/1088336/213342624-c4e208e6-ba01-4668-b472-a417ad9133a9.png">

See https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information

Excerpt:

> No more unauthenticated Git
> On the Git protocol side, unencrypted git:// offers no integrity or authentication, making it subject to tampering ... We’ll be disabling support for this protocol.
