### PR TITLE
fix universal hero base attack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43183,7 +43183,7 @@
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "6.0.9",
+        "react-error-overlay": "^6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",

--- a/src/utility/index.jsx
+++ b/src/utility/index.jsx
@@ -474,7 +474,7 @@ export function compileLevelOneStats(hero) {
       attack_speed: 1.25,
     },
     all: {
-      attackDamage: 1,
+      attackDamage: 0.7,
       armor: 0.2,
       health: 18,
       health_regen: 0.55,
@@ -502,14 +502,14 @@ export function compileLevelOneStats(hero) {
     attack_rate,
   } = hero;
 
-  const primaryAttrValue = hero[`base_${primary_attr}`];
-  const [agiValue, strValue, intValue] = [hero.base_agi, hero.base_str, hero.base_int];
 
+  const [agiValue, strValue, intValue] = [hero.base_agi, hero.base_str, hero.base_int];
+  const primaryAttrValue = primary_attr === "all" ? agiValue + strValue + intValue : hero[`base_${primary_attr}` ]
 
   return {
     ...hero,
-    base_attack_min: base_attack_min + (statsBonuses[primary_attr].attackDamage * primaryAttrValue),
-    base_attack_max: base_attack_max + (statsBonuses[primary_attr].attackDamage * primaryAttrValue),
+    base_attack_min: Math.round(base_attack_min + (statsBonuses[primary_attr].attackDamage * primaryAttrValue)),
+    base_attack_max: Math.round(base_attack_max + (statsBonuses[primary_attr].attackDamage * primaryAttrValue)),
     base_armor: round(base_armor + (statsBonuses[primary_attr].armor * agiValue)),
     base_health: round(base_health + (statsBonuses[primary_attr].health * strValue)),
     base_health_regen: round(base_health_regen + (base_health_regen * (statsBonuses[primary_attr].health_regen * strValue / 100))),


### PR DESCRIPTION
Universal heroes have **NaN** base attack
![image](https://github.com/odota/web/assets/30576056/54e1941b-7ce3-48d8-851c-98e4959f0d52)

It happens because **primaryAttrValue** retuns underfined if universal hero(there is no **base_all** property in **heroes.json**)
![image](https://github.com/odota/web/assets/30576056/2d620ee6-4dfd-4e50-b84b-4f2023cfaeb5)

screenshot after fix
![image](https://github.com/odota/web/assets/30576056/69c51636-7257-49a3-a336-67888798db49)

