### PR TITLE
Clear w/l display on player page switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .env
 yarn.lock
 src/*.d.ts
+.vite

--- a/src/components/Player/Header/PlayerHeader.jsx
+++ b/src/components/Player/Header/PlayerHeader.jsx
@@ -277,21 +277,19 @@ const PlayerHeader = ({
   picture,
   registered,
   plus,
-  playerLoading,
-  playerError,
+  loading,
+  error,
   small,
   playerSoloCompetitiveRank,
   loggedInUser,
   rankTier,
   leaderboardRank,
   strings,
-  playerWinLossLoading,
-  playerWinLossError,
 }) => {
-  if (playerError || playerWinLossError) {
+  if (error) {
     return <Error />;
   }
-  if (playerLoading || playerWinLossLoading) {
+  if (loading) {
     return <Facebook primaryColor="#666" secondaryColor="#ecebeb" width={400} height={60} animate />;
   }
 
@@ -373,10 +371,8 @@ PlayerHeader.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  playerLoading: state.app.player.loading,
-  playerWinLossLoading: state.app.playerWinLoss.loading,
-  playerError: state.app.player.error,
-  playerWinLossError: state.app.playerWinLoss.error,
+  loading: state.app.player.loading,
+  error: state.app.player.error,
   playerName: (state.app.player.data.profile || {}).personaname,
   officialPlayerName: (state.app.player.data.profile || {}).name,
   playerSoloCompetitiveRank: state.app.player.data.solo_competitive_rank,

--- a/src/components/Player/Header/PlayerHeader.jsx
+++ b/src/components/Player/Header/PlayerHeader.jsx
@@ -271,12 +271,27 @@ const getRankTierMedal = (rankTier, leaderboardRank) => {
 };
 
 const PlayerHeader = ({
-  playerName, officialPlayerName, playerId, picture, registered, plus, loading, error, small, playerSoloCompetitiveRank, loggedInUser, rankTier, leaderboardRank, strings,
+  playerName,
+  officialPlayerName,
+  playerId,
+  picture,
+  registered,
+  plus,
+  playerLoading,
+  playerError,
+  small,
+  playerSoloCompetitiveRank,
+  loggedInUser,
+  rankTier,
+  leaderboardRank,
+  strings,
+  playerWinLossLoading,
+  playerWinLossError,
 }) => {
-  if (error) {
+  if (playerError || playerWinLossError) {
     return <Error />;
   }
-  if (loading) {
+  if (playerLoading || playerWinLossLoading) {
     return <Facebook primaryColor="#666" secondaryColor="#ecebeb" width={400} height={60} animate />;
   }
 
@@ -358,8 +373,10 @@ PlayerHeader.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  loading: state.app.player.loading,
-  error: state.app.player.error,
+  playerLoading: state.app.player.loading,
+  playerWinLossLoading: state.app.playerWinLoss.loading,
+  playerError: state.app.player.error,
+  playerWinLossError: state.app.playerWinLoss.error,
   playerName: (state.app.player.data.profile || {}).personaname,
   officialPlayerName: (state.app.player.data.profile || {}).name,
   playerSoloCompetitiveRank: state.app.player.data.solo_competitive_rank,

--- a/src/components/Player/Header/PlayerStats.jsx
+++ b/src/components/Player/Header/PlayerStats.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // import ActionHelp from 'material-ui/svg-icons/action/help';
 import styled from 'styled-components';
+import { Facebook } from 'react-content-loader';
 import Error from '../../Error';
-import Spinner from '../../Spinner';
 import PlayedWith from './PlayedWith';
 import { PlayerStatsCard } from './Styled';
 import constants from '../../constants';
@@ -68,7 +68,7 @@ export const PlayerStatsCards = ({
     return <Error />;
   }
   if (loading) {
-    return <Spinner />;
+    return <Facebook primaryColor="#666" secondaryColor="#ecebeb" width={400} height={60} animate />;
   }
   return (
     <Styled>
@@ -109,7 +109,7 @@ PlayerStatsCards.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  loading: state.app.player.loading,
+  loading: state.app.playerWinLoss.loading,
   error: state.app.player.error,
   wins: state.app.playerWinLoss.data.win,
   losses: state.app.playerWinLoss.data.lose,

--- a/src/components/Player/Header/PlayerStats.jsx
+++ b/src/components/Player/Header/PlayerStats.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // import ActionHelp from 'material-ui/svg-icons/action/help';
 import styled from 'styled-components';
-import { Facebook } from 'react-content-loader';
+import Spinner from '../../Spinner';
 import Error from '../../Error';
 import PlayedWith from './PlayedWith';
 import { PlayerStatsCard } from './Styled';
@@ -68,7 +68,7 @@ export const PlayerStatsCards = ({
     return <Error />;
   }
   if (loading) {
-    return <Facebook primaryColor="#666" secondaryColor="#ecebeb" width={400} height={60} animate />;
+    return <Spinner />;
   }
   return (
     <Styled>

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
@@ -464,6 +465,7 @@ class TableHeroImage extends React.Component {
       predictedVictory,
       leaverStatus,
       strings,
+      match,
       hero = {},
     } = this.props;
     const { tooltipVisible } = this.state;
@@ -476,6 +478,9 @@ class TableHeroImage extends React.Component {
         this.setTooltipVisibility(false);
       },
     };
+
+    const { params } = match;
+    const { playerId } = params;
 
     return (
       <Styled style={expand}>
@@ -572,7 +577,7 @@ class TableHeroImage extends React.Component {
                   </div>
                 )}
                 {accountId ? (
-                  <a href={`/players/${accountId}`}>{title}</a>
+                  <TableLink to={`/players/${accountId}`}>{title}</TableLink>
                 ) : (
                   title
                 )}
@@ -828,4 +833,4 @@ const mapStateToProps = (state) => ({
   strings: state.app.strings,
 });
 
-export default connect(mapStateToProps)(TableHeroImage);
+export default withRouter(connect(mapStateToProps)(TableHeroImage));

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -572,7 +572,7 @@ class TableHeroImage extends React.Component {
                   </div>
                 )}
                 {accountId ? (
-                  <TableLink to={`/players/${accountId}`}>{title}</TableLink>
+                  <a href={`/players/${accountId}`}>{title}</a>
                 ) : (
                   title
                 )}

--- a/src/components/Visualizations/Table/HeroImage.jsx
+++ b/src/components/Visualizations/Table/HeroImage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
@@ -465,7 +464,6 @@ class TableHeroImage extends React.Component {
       predictedVictory,
       leaverStatus,
       strings,
-      match,
       hero = {},
     } = this.props;
     const { tooltipVisible } = this.state;
@@ -478,10 +476,7 @@ class TableHeroImage extends React.Component {
         this.setTooltipVisibility(false);
       },
     };
-
-    const { params } = match;
-    const { playerId } = params;
-
+  
     return (
       <Styled style={expand}>
         <HeroImageContainer>
@@ -833,4 +828,4 @@ const mapStateToProps = (state) => ({
   strings: state.app.strings,
 });
 
-export default withRouter(connect(mapStateToProps)(TableHeroImage));
+export default connect(mapStateToProps)(TableHeroImage);


### PR DESCRIPTION
Cause of issue:
- the "getPlayerWinLoss" API is being called while navigating between player profiles
- however, the "playerWinLoss.loading" state is not being checked while rendering the components

Proposed changes:
- added a check for "playerWinLoss.loading"
- placed the above check inside "PlayerHeader" component because the component relies on data sets from 2 individual APIs
- this is to prevent different portions of the component from displaying the desired content at different speeds

fixes #3148 

