### PR TITLE
feat(issue-3133): hide player matches if player profile is private

### DIFF
--- a/src/components/Player/Header/PlayerHeader.jsx
+++ b/src/components/Player/Header/PlayerHeader.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Avatar from 'material-ui/Avatar';
 import Badge from 'material-ui/Badge';
+import LockIcon from '@material-ui/icons/Lock';
 import styled from 'styled-components';
 import { Facebook } from 'react-content-loader';
 import { rankTierToString } from '../../../utility';
 import Error from '../../Error';
 import PlayerStats from './PlayerStats';
 import PlayerBadges from './PlayerBadges';
-import PlayerButtons from './PlayerButtons';
+import PlayerButtons from './PlayerButtons'
 import constants from '../../constants';
 
 const Styled = styled.div`
@@ -42,6 +43,7 @@ grid-template-columns: 1fr minmax(min-content, ${constants.appWidth}px) 1fr;
   flex-direction: row;
   justify-content: flex-start;
   flex-wrap: wrap;
+  margin-bottom: 2%;
 
   @media only screen and (max-width: 768px) {
     flex-direction: column;
@@ -188,6 +190,11 @@ grid-template-columns: 1fr minmax(min-content, ${constants.appWidth}px) 1fr;
   }
 }
 
+.lockIcon {
+  @media only screen and (max-width: 768px) {
+    text-align: center;
+  }
+}
 `;
 
 const LARGE_IMAGE_SIZE = 124;
@@ -285,6 +292,7 @@ const PlayerHeader = ({
   rankTier,
   leaderboardRank,
   strings,
+  isPlayerProfilePrivate,
 }) => {
   if (error) {
     return <Error />;
@@ -340,8 +348,16 @@ const PlayerHeader = ({
               <span className="playerName">{officialPlayerName || playerName}</span>
               <PlayerBadges playerId={playerId} />
             </div>
-            <PlayerStats playerId={playerId} loggedInId={loggedInUser && String(loggedInUser.account_id)} compact={!small} />
-            <PlayerButtons playerId={playerId} playerSoloCompetitiveRank={playerSoloCompetitiveRank} compact={!small} />
+            {isPlayerProfilePrivate ? (
+              <div className="lockIcon">
+                <LockIcon />   
+              </div>
+            ) : (
+              <>
+                <PlayerStats playerId={playerId} loggedInId={loggedInUser && String(loggedInUser.account_id)} compact={!small} />
+                <PlayerButtons playerId={playerId} playerSoloCompetitiveRank={playerSoloCompetitiveRank} compact={!small} />
+              </>
+            )}
           </div>
           <div style={{ display: 'flex' }}>
             {getDotaPlusBadge(plus, strings)}
@@ -368,6 +384,7 @@ PlayerHeader.propTypes = {
   rankTier: PropTypes.number,
   leaderboardRank: PropTypes.number,
   strings: PropTypes.shape({}),
+  isPlayerProfilePrivate: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/Player/PlayerProfilePrivate/index.jsx
+++ b/src/components/Player/PlayerProfilePrivate/index.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+import LockIcon from '@material-ui/icons/Lock';
+import config from '../../../config';
+
+const Styled = styled.div`
+text-align: center;
+padding-top: 5%;
+
+.playerProfilePrivateTitle {
+  font-size: 2rem;
+  margin-bottom: 1%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.lockIcon {
+  font-size: 1.8rem;
+  margin-right: 2%;
+}
+
+.playerProfilePrivateDescription {
+  margin-bottom: 2%;
+}
+
+.signInWithSteamButton {
+  border: solid 1px #FFFFFF;
+  color: #FFFFFF;
+  padding: 1% 2%;
+}
+`
+
+const PlayerProfilePrivate = ({ strings }) => {
+  const handleButtonClick = () => window.location.href = `${config.VITE_API_HOST}/login`
+
+  return (
+    <Styled>
+      <div>
+        <div className="playerProfilePrivateTitle">
+          <LockIcon className="lockIcon" />
+          <div>{(strings.player_profile_private_title)}</div>
+        </div>
+        <div className="playerProfilePrivateDescription">{strings.player_profile_private_description}</div>
+        <Button
+          className="signInWithSteamButton"
+          onClick={handleButtonClick}
+        >
+          {strings.sign_in_with_steam}
+        </Button>
+      </div>
+    </Styled>
+  );
+}
+
+PlayerProfilePrivate.PropTypes = {
+  strings: PropTypes.shape({}),
+}
+
+const mapStateToProps = state => ({
+  strings: state.app.strings,
+})
+
+export default connect(mapStateToProps)(PlayerProfilePrivate);

--- a/src/components/Player/playerPages.jsx
+++ b/src/components/Player/playerPages.jsx
@@ -90,7 +90,8 @@ const playerPages = strings => [{
   content: (playerId, routeParams, location) => (<ActivityPage playerId={playerId} routeParams={routeParams} location={location} />),
 }];
 
-export default (playerId, strings) => playerPages(strings).map(page => ({
+export default (playerId, strings, isPlayerProfilePrivate) => playerPages(strings).map(page => ({
   ...page,
   route: `/players/${playerId}/${page.key}`,
+  disabled: isPlayerProfilePrivate,
 }));

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1203,5 +1203,8 @@
   "killed": "killed",
   "team_courier": "{team}'s courier",
   "slain_roshan": "Have slain Roshan",
-  "drew_first_blood": "Drew First Blood"
+  "drew_first_blood": "Drew First Blood",
+  "player_profile_private_title": "THIS PROFILE IS PRIVATE" ,
+  "player_profile_private_description": "If this is your profile, sign in with Steam in order to view your statistics.",
+  "sign_in_with_steam": "Sign in with Steam"
 }


### PR DESCRIPTION
1. Added retrieving of list of pro player IDs
2. Player profile should be private if player account id is not within the list of pro player IDs, and the player's "fh_unavailable" property is true
3. Disabled tabs if player profile is private
4. Added CTA to direct players to login if their profile is private, but they wish to see their stats


![Uploading Screenshot 2024-02-11 151555.png…]()
