### PR TITLE
Add 7.34 draft order

### DIFF
--- a/src/components/Match/Draft/Draft.jsx
+++ b/src/components/Match/Draft/Draft.jsx
@@ -188,7 +188,11 @@ const Draft = ({
   let orderOne = [];
   let orderTwo = [];
   let picks = [];
-  if (startTime > 1629255201) { // post 7.30
+  if (startTime > 1691534760) { // post 7.34
+    orderOne = [1, 4, 7, 8, 10, 11, 14, 15, 18, 19, 22, 23];
+    orderTwo = [2, 3, 5, 6, 9, 12, 13, 16, 17, 20, 21, 24];
+    picks = [8, 9, 13, 14, 15, 16, 17, 18, 23, 24];
+  } else if (startTime > 1629255201) { // post 7.30
     orderOne = [1, 3, 5, 8, 9, 11, 13, 16, 17, 19, 21, 23];
     orderTwo = [2, 4, 6, 7, 10, 12, 14, 15, 18, 20, 22, 24];
     picks = [5, 6, 7, 8, 15, 16, 17, 18, 23, 24];


### PR DESCRIPTION
[Patch 7.34](https://www.dota2.com/patches/7.34) changed the draft order and a corresponding mapping was not added to OpenDota. This PR adds support for this new draft order.

---

Tested by using the Battle Cup match [7580513318](https://www.opendota.com/matches/7580513318/draft), which was played on 2024-02-10. 

The draft should look as follows (the Dota client has some issues when jumping ahead in draft in replays it seems; the last pick for Dire was a Dragon Knight)
![draft](https://github.com/odota/web/assets/15884513/9523dbbd-195f-4633-a0f5-90cfca76a679)

Prior to this change, the draft of a parsed game on OpenDota incorrectly showed the following:
![before](https://github.com/odota/web/assets/15884513/612ad4ed-5c10-4a3b-bdfd-ad5cb2e6ad4d)

After this change, the draft appears correct in a parsed game:
![after](https://github.com/odota/web/assets/15884513/8eb4e0da-7069-43a9-9109-c89e876d8116)

The [Team Liquid v Azure Ray game](https://www.opendota.com/matches/7588089287/draft), played today, also now displays correctly:
![tl-xg](https://github.com/odota/web/assets/15884513/030c013d-97d1-4fb0-be35-3b9b500c546e)


Happy to test any additional matches as desired.

---

Note: the timestamp correlates to Tuesday, August 8, 2023 22:46:00 GMT, which I correlated to build ID **11896549** in [Dota's SteamDB entry](https://steamdb.info/app/570/patchnotes/). I'm not sure if there's a more formal way to get an exact timestamp on when this new draft order should take effect, but I'm happy to do more digging if we'd prefer a more precise time.

![734-steamdb](https://github.com/odota/web/assets/15884513/eb07bd10-4de6-4da2-a0cb-3ac08f816926)
