### PR TITLE
feat(issue-3133): include logged in user scenario

### DIFF
--- a/src/components/Player/PlayerProfilePrivate/index.jsx
+++ b/src/components/Player/PlayerProfilePrivate/index.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+import LockIcon from '@material-ui/icons/Lock';
+import config from '../../../config';
+
+const Styled = styled.div`
+text-align: center;
+padding-top: 5%;
+
+.playerProfilePrivateTitle {
+  font-size: 2rem;
+  margin-bottom: 1%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.lockIcon {
+  font-size: 1.8rem;
+  margin-right: 2%;
+}
+
+.playerProfilePrivateDescription {
+  margin-bottom: 2%;
+}
+
+.signInWithSteamButton {
+  border: solid 1px #FFFFFF;
+  color: #FFFFFF;
+  padding: 1% 2%;
+}
+`
+
+const PlayerProfilePrivate = ({ strings }) => {
+  const handleButtonClick = () => {
+    window.location.href = `${config.VITE_API_HOST}/login`;
+  };
+  const playerProfilePrivateTitle = (strings.player_profile_private_title || "").toUpperCase();
+
+  return (
+    <Styled>
+      <div>
+        <div className="playerProfilePrivateTitle">
+          <LockIcon className="lockIcon" />
+          <div>{playerProfilePrivateTitle}</div>
+        </div>
+        <div className="playerProfilePrivateDescription">{strings.player_profile_private_description}</div>
+        <Button
+          className="signInWithSteamButton"
+          onClick={handleButtonClick}
+        >
+          {strings.sign_in_with_steam}
+        </Button>
+      </div>
+    </Styled>
+  );
+}
+
+PlayerProfilePrivate.propTypes = {
+  strings: PropTypes.shape({}),
+}
+
+const mapStateToProps = state => ({
+  strings: state.app.strings,
+})
+
+export default connect(mapStateToProps)(PlayerProfilePrivate);

--- a/src/components/Player/playerPages.jsx
+++ b/src/components/Player/playerPages.jsx
@@ -90,7 +90,8 @@ const playerPages = strings => [{
   content: (playerId, routeParams, location) => (<ActivityPage playerId={playerId} routeParams={routeParams} location={location} />),
 }];
 
-export default (playerId, strings) => playerPages(strings).map(page => ({
+export default (playerId, strings, isPlayerProfilePublic) => playerPages(strings).map(page => ({
   ...page,
   route: `/players/${playerId}/${page.key}`,
+  disabled: !isPlayerProfilePublic,
 }));

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1203,5 +1203,8 @@
   "killed": "killed",
   "team_courier": "{team}'s courier",
   "slain_roshan": "Have slain Roshan",
-  "drew_first_blood": "Drew First Blood"
+  "drew_first_blood": "Drew First Blood",
+  "player_profile_private_title": "This profile is private" ,
+  "player_profile_private_description": "If this is your profile, sign in with Steam in order to view your statistics.",
+  "sign_in_with_steam": "Sign in with Steam"
 }


### PR DESCRIPTION
Player profile is public if:
1. Player is a pro player
2. Player's match history is not disabled (i.e. "fh_unavailable" is false)
3. Player's match history is disabled, but the player is logged in and is viewing own profile

Player profile is private for all other scenarios. It is much easier to just check if the player profile is public, since there seems to be fewer + less complicated scenarios

Do let me know if I have missed out on any scenarios!


![image](https://github.com/odota/web/assets/65485512/8abeb3b4-f2b0-4d7b-bde9-ce07b8a04e8a)
^ this is how it will look like if we don't hide the W/L stat