### PR TITLE
Fixed size of icons for backpack item costs

### DIFF
--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -119,8 +119,8 @@ const HeaderText = styled.div`
 `;
 
 const ResourceIcon = styled.img`
-  width: 16px;
-  height: 16px;
+  width: 16px !important;
+  height: 16px !important;
   vertical-align: sub;
   margin-right: 5px;
 `;

--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -119,8 +119,8 @@ const HeaderText = styled.div`
 `;
 
 const ResourceIcon = styled.img`
-  width: 16px !important;
-  height: 16px !important;
+  max-width: 16px;
+  max-height: 16px;
   vertical-align: sub;
   margin-right: 5px;
 `;
@@ -284,7 +284,7 @@ const Ability = (item, type, title, description, hasNonPassive) => {
           <div>
             {item.mc && type !== 'passive' &&
               <span className="entry">
-                <ResourceIcon src='/assets/images/dota2/ability_manacost.png' alt='Mana icon' />
+                <ResourceIcon src='/assets/images/dota2/ability_manacost.png' alt='Mana icon' height="16px" />
                 <span className='values'>{item.mc}</span>
               </span>}
             {item.hc && type !== 'passive' &&

--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -284,7 +284,7 @@ const Ability = (item, type, title, description, hasNonPassive) => {
           <div>
             {item.mc && type !== 'passive' &&
               <span className="entry">
-                <ResourceIcon src='/assets/images/dota2/ability_manacost.png' alt='Mana icon' height="16px" />
+                <ResourceIcon src='/assets/images/dota2/ability_manacost.png' alt='Mana icon' />
                 <span className='values'>{item.mc}</span>
               </span>}
             {item.hc && type !== 'passive' &&


### PR DESCRIPTION
This fixes the issue with the sizing of the cost icons described in #3163 by @builder-247.

![image](https://github.com/odota/web/assets/91514586/d2be3fd5-d1f7-4631-979a-9a8be0618b42)
