### PR TITLE
css fixes

### DIFF
--- a/src/components/ItemTooltip/index.jsx
+++ b/src/components/ItemTooltip/index.jsx
@@ -211,7 +211,7 @@ const AbilityComponent = styled.div`
   margin: 10px 9px;
 
   & .ability-name {
-    font-size: 14px;
+    font-size: 13px;
     font-weight: bold;
     vertical-align: middle;
     padding-left: 4px;

--- a/src/components/Visualizations/inflictorWithValue.jsx
+++ b/src/components/Visualizations/inflictorWithValue.jsx
@@ -225,7 +225,7 @@ class InflictorWithValue extends React.Component {
             onMouseEnter={this.setShowTooltip}
           >
             {(!type || type === 'purchase' || type === 'backpack' || type === 'neutral') &&
-              <object data={image} height="27px" width="37px" type="image/png">
+              <object data={image} height="27px" width={ability ? '27px' : '37px'} type="image/png">
                 <img src="/assets/images/Dota2Logo.svg" alt="Dota 2 Logo" style={{ filter: 'grayscale(60%)', height: '27px' }} />
               </object>}
             {type === 'buff' &&


### PR DESCRIPTION
* Reduced font size of item tooltip ability title - even the longer ones should now fit on one line, e.g. Book of the Dead
* Fixed a regression from https://github.com/odota/web/pull/3157 where hero ability icons would be too wide