### PR TITLE
Improve item abilities and attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ace-builds": "^1.4.7",
         "core-js": "^3.6.4",
         "dota2-emoticons": "^1.0.3",
-        "dotaconstants": "^8.5.0",
+        "dotaconstants": "^8.6.0",
         "fuzzy": "^0.1.3",
         "heatmap.js": "github:muyao1987/heatmap.js",
         "history": "^4.10.1",
@@ -5880,9 +5880,9 @@
       "integrity": "sha512-arwwgkRRsbTnfkHJWCIkSijmd5BcVwNrBCU2I1QXN1bQ557+/Ikmgs9d6HZnA1QvIlkM6M79SdermOvg9Z01Hw=="
     },
     "node_modules/dotaconstants": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/dotaconstants/-/dotaconstants-8.5.0.tgz",
-      "integrity": "sha512-dcxFwPOjfTFim81pVtehQH8fFFvB5balPUdKwTqrfgoTAAopGVBM+UeiSAXc2FafbqIJVBaquuDfe6FESikD5A=="
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotaconstants/-/dotaconstants-8.6.0.tgz",
+      "integrity": "sha512-WA1VFKH+SzF6CQV8uNS1ClGORiFmmkOnWBV3AlnVXS/6F1gpkD6DiIquIC1t6mgh8kQUT/KiB7iSDPrWBUZ6ug=="
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -17285,9 +17285,9 @@
       "integrity": "sha512-arwwgkRRsbTnfkHJWCIkSijmd5BcVwNrBCU2I1QXN1bQ557+/Ikmgs9d6HZnA1QvIlkM6M79SdermOvg9Z01Hw=="
     },
     "dotaconstants": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/dotaconstants/-/dotaconstants-8.5.0.tgz",
-      "integrity": "sha512-dcxFwPOjfTFim81pVtehQH8fFFvB5balPUdKwTqrfgoTAAopGVBM+UeiSAXc2FafbqIJVBaquuDfe6FESikD5A=="
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotaconstants/-/dotaconstants-8.6.0.tgz",
+      "integrity": "sha512-WA1VFKH+SzF6CQV8uNS1ClGORiFmmkOnWBV3AlnVXS/6F1gpkD6DiIquIC1t6mgh8kQUT/KiB7iSDPrWBUZ6ug=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ace-builds": "^1.4.7",
     "core-js": "^3.6.4",
     "dota2-emoticons": "^1.0.3",
-    "dotaconstants": "^8.5.0",
+    "dotaconstants": "^8.6.0",
     "fuzzy": "^0.1.3",
     "heatmap.js": "github:muyao1987/heatmap.js",
     "history": "^4.10.1",


### PR DESCRIPTION
This PR fixes two issues with item tooltips:
* Ability name detection was detection based on a regex relying on capitalization, which was inconsistent for a few items e.g. Bloodstone
* Added support for uppercase stats displayed at the bottom:
![image](https://github.com/odota/web/assets/14019974/06f20fdc-4edc-4307-b780-f5fae2c71055)


Requires a release from https://github.com/odota/dotaconstants/pull/156