### PR TITLE
fix neutral item slot image fit

### DIFF
--- a/src/components/Visualizations/inflictorWithValue.jsx
+++ b/src/components/Visualizations/inflictorWithValue.jsx
@@ -79,6 +79,7 @@ display: inline-block;
     > img {
       height: 30px;
       width: 30px;
+      object-fit: cover;
       border-radius: 15px;
       position: relative;
       bottom: 1px;


### PR DESCRIPTION
Accidentally removed in https://github.com/odota/web/pull/3199