### PR TITLE
Fix: Typo in zh-CN

### DIFF
--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -393,7 +393,7 @@
   "heading_is_radiant": "阵营",
   "heading_avg_and_max": "平均/最大值",
   "heading_total_matches": "所有比赛",
-  "heading_median": "中路",
+  "heading_median": "中位数",
   "heading_distinct_heroes": "按英雄分类",
   "heading_team_elo_rankings": "Elo等级分排名",
   "heading_ability_build": "技能加点",


### PR DESCRIPTION
Fix Chinese language typo for 'heading_median', should be '中位数' instead of ‘中路'

Test Evidence:
<img width="612" alt="截屏2025-01-06 下午10 11 48" src="https://github.com/user-attachments/assets/e05d7ce0-c4e3-4b02-9c48-9862f918d0bb" />
