### PR TITLE
Fix division by zero error in wordcloud scale

### DIFF
--- a/src/components/Wordcloud/Wordcloud.jsx
+++ b/src/components/Wordcloud/Wordcloud.jsx
@@ -33,7 +33,7 @@ function updateWordCloud(wordCounts, cloudDomId) {
   const minSize = 8;
 
   // @howardchung implementation of scaling
-  const scale = maxSize / Math.log(max);
+  const scale = maxSize / (Math.log(max) + 1);
   // var scale = max_size/max;
   // take the log of each count and scale them up to top_size
   // use log since words such as "gg" tend to dominate


### PR DESCRIPTION
If all wordcounts were 1, a division by zero error would cause the wordcloud to not be rendered.

Fixes https://github.com/odota/web/issues/3237