### PR TITLE
add null-safety for state in PlayedWith component to avoid page crash

### DIFF
--- a/src/components/Player/Header/PlayedWith.tsx
+++ b/src/components/Player/Header/PlayedWith.tsx
@@ -45,7 +45,7 @@ class PlayedWith extends React.Component<PlayedWithProps, { win: number, lose: n
   }
   render() {
     const { strings } = this.props;
-    return this.state?.win && this.state?.lose ? (
+    return this.state !== null ? (
       <div
         style={{
           display: shouldShow(this.props) ? 'inline' : 'none',


### PR DESCRIPTION
**Why?**

After [last changes](https://github.com/odota/web/commit/2f44a96e8c225209baf7633207f6c36b4951caf4) in player's header, [player's page](https://www.opendota.com/players/301278114) failed to load, because of void Promise result from fetch in PlayedWith component.

<img width="1440" height="308" alt="image" src="https://github.com/user-attachments/assets/1f132f2f-3036-43ed-ab97-5fe9701ed3a4" />