### PR TITLE
Refactor promise chains to async/await

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -21,38 +21,40 @@ export default function action(
       type: `ERROR/${type}`,
       error,
     });
-    const fetchDataWithRetry = (delay: number) =>
-      fetch(
-        url,
-        url.startsWith(config.VITE_API_HOST) ? { credentials: "include" } : {},
-      )
-        .then((response) => {
-          if (!response.ok || !response.status) {
-            const err: any = new Error();
-            err.fetchError = true;
-            dispatch(getError(response.status));
-            if (response.status >= 400 && response.status < 500) {
-              err.clientError = true;
-              err.message = "fetch failed - client error";
-            } else {
-              err.message = "fetch failed - retrying";
-            }
-            throw err;
+    const fetchDataWithRetry = async (delay: number) => {
+      try {
+        const response = await fetch(
+          url,
+          url.startsWith(config.VITE_API_HOST)
+            ? { credentials: "include" }
+            : {},
+        );
+        if (!response.ok || !response.status) {
+          const err: any = new Error();
+          err.fetchError = true;
+          dispatch(getError(response.status));
+          if (response.status >= 400 && response.status < 500) {
+            err.clientError = true;
+            err.message = "fetch failed - client error";
+          } else {
+            err.message = "fetch failed - retrying";
           }
-          return response.json();
-        })
-        .then(transform || ((json) => json))
-        .then((json) => dispatch(getDataOk(json)))
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error(e);
-          if (e.fetchError && !e.clientError) {
-            setTimeout(() => fetchDataWithRetry(delay + 3000), delay);
-          }
-          if (!e.fetchError) {
-            throw e;
-          }
-        });
+          throw err;
+        }
+        const json = await response.json();
+        const transformedJson = transform ? await transform(json) : json;
+        return dispatch(getDataOk(transformedJson));
+      } catch (e: any) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        if (e.fetchError && !e.clientError) {
+          setTimeout(() => fetchDataWithRetry(delay + 3000), delay);
+        }
+        if (!e.fetchError) {
+          throw e;
+        }
+      }
+    };
     dispatch(getDataStart());
     return fetchDataWithRetry(1000);
   };

--- a/src/components/Combos/Combos.tsx
+++ b/src/components/Combos/Combos.tsx
@@ -315,18 +315,18 @@ class Combos extends React.Component<{ strings: Strings }> {
   sendRequest = () => {
     const { teamA, teamB } = this.state;
 
-    this.setState({ loading: true }, () =>
-      fetch(
+    this.setState({ loading: true }, async () => {
+      const response = await fetch(
         `${config.VITE_API_HOST}/api/` +
           `${
             this.state.queryType === "pro"
               ? `explorer?sql=${encodeURIComponent(this.buildQueryString())}`
               : `findMatches?${querystring.stringify({ teamA, teamB })}`
           }`,
-      )
-        .then((res) => res.json())
-        .then(this.handleResponse),
-    );
+      );
+      const json = await response.json();
+      this.handleResponse(json);
+    });
   };
 
   handleSubmit = () => {

--- a/src/components/Explorer/Explorer.tsx
+++ b/src/components/Explorer/Explorer.tsx
@@ -103,7 +103,7 @@ class Explorer extends React.Component<
     this.instantiateEditor();
   }
 
-  componentDidUpdate(nextProps: ExplorerProps) {
+  async componentDidUpdate(nextProps: ExplorerProps) {
     if (
       this.editor &&
       !this.completersSet &&
@@ -112,18 +112,16 @@ class Explorer extends React.Component<
       nextProps.leagues.length
     ) {
       this.completersSet = true;
-      fetch(`${config.VITE_API_HOST}/api/schema`)
-        .then((resp) => resp.json())
-        .then((schema) => {
-          this.editor.completers = [
-            autocomplete(
-              schema,
-              nextProps.proPlayers,
-              nextProps.teams,
-              nextProps.leagues,
-            ),
-          ];
-        });
+      const response = await fetch(`${config.VITE_API_HOST}/api/schema`);
+      const schema = await response.json();
+      this.editor.completers = [
+        autocomplete(
+          schema,
+          nextProps.proPlayers,
+          nextProps.teams,
+          nextProps.leagues,
+        ),
+      ];
     }
   }
 
@@ -159,14 +157,14 @@ class Explorer extends React.Component<
     );
   };
 
-  sendRequest = () => {
+  sendRequest = async () => {
     this.syncWindowHistory();
     const sqlString = this.getSqlString();
-    return fetch(
+    const response = await fetch(
       `${config.VITE_API_HOST}/api/explorer?sql=${encodeURIComponent(sqlString)}`,
-    )
-      .then((resp) => resp.json())
-      .then(this.handleResponse);
+    );
+    const json = await response.json();
+    return this.handleResponse(json);
   };
 
   handleQuery = () => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -272,7 +272,11 @@ const Header = ({
   const strings = useStrings();
 
   useEffect(() => {
-    import("../Announce/Announce").then((ann: any) => setAnnounce(ann.default));
+    const loadAnnounce = async () => {
+      const ann = await import("../Announce/Announce");
+      setAnnounce(ann.default);
+    };
+    void loadAnnounce();
   }, []);
 
   const navbarPages = [

--- a/src/components/Meta/Meta.tsx
+++ b/src/components/Meta/Meta.tsx
@@ -81,18 +81,18 @@ class Meta extends React.Component<
     );
   };
 
-  handleQuery = () => {
+  handleQuery = async () => {
     this.setState({
       ...this.state,
       loading: true,
     });
     this.syncWindowHistory();
     const sqlString = this.state.sql;
-    return fetch(
+    const response = await fetch(
       `${config.VITE_API_HOST}/api/explorer?sql=${encodeURIComponent(sqlString)}`,
-    )
-      .then((resp) => resp.json())
-      .then(this.handleResponse);
+    );
+    const json = await response.json();
+    return this.handleResponse(json);
   };
 
   handleResponse = (json: any) => {

--- a/src/hooks/useAbilities.hook.ts
+++ b/src/hooks/useAbilities.hook.ts
@@ -5,13 +5,14 @@ let data: Record<string, any>;
 export const useAbilities = () => {
   const [abilities, setAbilities] = useState(data);
   useEffect(() => {
-    import("../../node_modules/dotaconstants/build/abilities.json").then(
-      (imp) => {
-        const def = imp.default;
-        setAbilities(def);
-        data = def;
-      },
-    );
+    const loadAbilities = async () => {
+      const imp =
+        await import("../../node_modules/dotaconstants/build/abilities.json");
+      const def = imp.default;
+      setAbilities(def);
+      data = def;
+    };
+    void loadAbilities();
   }, []);
   return abilities;
 };

--- a/src/hooks/useFetch.hook.ts
+++ b/src/hooks/useFetch.hook.ts
@@ -5,13 +5,14 @@ export function useFetch<T>(url: string) {
   useEffect(() => {
     if (url) {
       let ignore = false;
-      fetch(url)
-        .then((response) => response.json())
-        .then((json) => {
-          if (!ignore) {
-            setData(json);
-          }
-        });
+      const fetchData = async () => {
+        const response = await fetch(url);
+        const json = await response.json();
+        if (!ignore) {
+          setData(json);
+        }
+      };
+      void fetchData();
       return () => {
         ignore = true;
       };

--- a/src/hooks/useHeroAbilities.hook.ts
+++ b/src/hooks/useHeroAbilities.hook.ts
@@ -5,13 +5,14 @@ let data: Record<string, any>;
 export const useHeroAbilities = () => {
   const [heroAbilities, setHeroAbilities] = useState(data);
   useEffect(() => {
-    import("../../node_modules/dotaconstants/build/hero_abilities.json").then(
-      (imp) => {
-        const def = imp.default;
-        setHeroAbilities(def);
-        data = def;
-      },
-    );
+    const loadHeroAbilities = async () => {
+      const imp =
+        await import("../../node_modules/dotaconstants/build/hero_abilities.json");
+      const def = imp.default;
+      setHeroAbilities(def);
+      data = def;
+    };
+    void loadHeroAbilities();
   }, []);
   return heroAbilities;
 };

--- a/src/hooks/usePatchnotes.hook.ts
+++ b/src/hooks/usePatchnotes.hook.ts
@@ -5,13 +5,14 @@ let data: PatchNotes;
 export const usePatchnotes = () => {
   const [patchnotes, setPatchnotes] = useState(data);
   useEffect(() => {
-    import("../../node_modules/dotaconstants/build/patchnotes.json").then(
-      (imp) => {
-        const def = imp.default;
-        setPatchnotes(def);
-        data = def;
-      },
-    );
+    const loadPatchnotes = async () => {
+      const imp =
+        await import("../../node_modules/dotaconstants/build/patchnotes.json");
+      const def = imp.default;
+      setPatchnotes(def);
+      data = def;
+    };
+    void loadPatchnotes();
   }, []);
   return patchnotes;
 };


### PR DESCRIPTION
## Summary

- replace fetch promise chains with `async`/`await`
- convert lazy dynamic imports in hooks and the header
- preserve the existing retry and error propagation behavior

## Testing

- `npm run typecheck`
- `npm run build`
- Prettier check on all changed files
- verified no `.then()` or `.catch()` calls remain in `src`

Closes #3361
