### PR TITLE
Show smoke icon on smoked kills in match log

### DIFF
--- a/src/components/Match/MatchLog.tsx
+++ b/src/components/Match/MatchLog.tsx
@@ -12,6 +12,7 @@ import {
 import FormField from "../Form/FormField";
 import { StyledLogFilterForm } from "./StyledMatch";
 import HeroImage from "../Visualizations/HeroImage";
+import config from "../../config";
 import sword from "../Icons/Sword.svg";
 import { IconBloodDrop, IconRoshan } from "../Icons";
 import lightning from "../Icons/Lightning.svg";
@@ -502,6 +503,15 @@ function EntryMessage({ entry, strings }: { entry: any; strings: Strings }) {
           <span className="smallMutedText">{strings.killed}</span>
           <HeroImage id={hero.id} className="detailIcon" isIcon />
           <span className="smallBoldText">{hero.localized_name}</span>
+          {entry.smoke && (
+            <Tooltip title={strings.smoke_kill}>
+              <img
+                src={`${config.VITE_IMAGE_CDN}/apps/dota2/images/dota_react/items/smoke_of_deceit.png`}
+                alt={strings.smoke_kill}
+                className="detailIcon"
+              />
+            </Tooltip>
+          )}
         </>
       );
     }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1208,6 +1208,7 @@
   "killed": "killed",
   "team_courier": "{team}'s courier",
   "slain_roshan": "Have slain Roshan",
+  "smoke_kill": "Kill from Smoke of Deceit",
   "destroyed_tormentor": "Have destroyed the Tormentor",
   "drew_first_blood": "Drew First Blood",
   "player_profile_private_title": "This profile is private",


### PR DESCRIPTION
Kill entries in the Log tab get a Smoke of Deceit icon (with tooltip) when the kill has `smoke: true`, the field proposed in odota/parser#91. Kills without the field render as today.

![smoke in match log](https://raw.githubusercontent.com/geracosta/web/assets/smoke-log-demo.jpg)

Draft until the parser side lands.