### PR TITLE
Show estimated position in the overview table

### DIFF
--- a/src/components/Match/matchColumns.tsx
+++ b/src/components/Match/matchColumns.tsx
@@ -558,6 +558,19 @@ export default (strings: Strings, beta = false) => {
           : [],
       );
 
+    if (match.players.some((p) => p.position_est)) {
+      cols.splice(1, 0, {
+        displayName: strings.th_position_est,
+        tooltip: strings.tooltip_position_est,
+        field: "position_est",
+        sortFn: true,
+        textAlign: "center",
+        paddingRight: 7,
+        width: 35,
+        displayFn: (row: MatchPlayer, col: any, field: any) => field || "-",
+      });
+    }
+
     return cols;
   };
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -150,6 +150,7 @@ type MatchPlayer = {
   tower_damage: number;
   benchmarks: Record<string, any>;
   computed_mmr: number;
+  position_est?: number;
 };
 
 type RouterProps = {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -818,6 +818,8 @@
   "th_target_abilities": "Ability Targets",
   "th_mmr": "MMR",
   "th_level": "LVL",
+  "th_position_est": "POS",
+  "tooltip_position_est": "Position estimated from lane role and early farm priority (1 = carry, 5 = hard support)",
   "th_kills": "K",
   "th_kills_per_min": "KPM",
   "th_deaths": "D",


### PR DESCRIPTION
Adds a POS column to the match Overview using the `position_est` field from odota/core#2974 (estimated from lane role plus early farm priority, 98.9% exact against pro lineups). It's computed at query time so it works for any parsed match already, no reparse needed. The column only appears when the match has the data, so unparsed matches look the same as today.

In the screenshot the estimates line up with the actual roles: No[o]ne- pos 2, Satanic pos 1, Fly pos 5.

![position column](https://raw.githubusercontent.com/geracosta/web/assets/position-badges-demo.jpg)