### PR TITLE
Show bracket percentile in benchmark tooltips

### DIFF
--- a/src/components/Match/matchColumns.tsx
+++ b/src/components/Match/matchColumns.tsx
@@ -685,6 +685,15 @@ export default (strings: Strings, beta = false) => {
                         strings[`th_${key}` as keyof Strings],
                         percent,
                       )}
+                      {bm.pct_bracket !== undefined && (
+                        <>
+                          <br />
+                          {formatTemplateToString(
+                            strings.benchmarks_description_bracket,
+                            Number(bm.pct_bracket * 100).toFixed(2),
+                          )}
+                        </>
+                      )}
                     </ReactTooltip>
                   </div>
                 );

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -118,6 +118,7 @@
   "barracks_value_1024": "Radiant Top Melee",
   "barracks_value_2048": "Radiant Top Ranged",
   "benchmarks_description": "{0} {1} is equal or higher than {2}% of recent performances on this hero",
+  "benchmarks_description_bracket": "Equal or higher than {0}% at this match's average rank",
   "fantasy_description": "{0} for {1} points",
   "building_melee_rax": "Melee Barracks",
   "building_range_rax": "Ranged Barracks",


### PR DESCRIPTION
When a benchmark has the `pct_bracket` field from odota/core#2979, the cell tooltip gets a second line with the percentile against this match's own rank bracket. Cells without the field render exactly as today.

Screenshot from a local run against a Legend-bracket ranked match, with the bracket percentiles derived from the production /benchmarks?bracket= distributions:

![bracket percentile tooltip](https://raw.githubusercontent.com/geracosta/web/assets/bracket-tooltip-demo.jpg)

Draft until the core side lands.