### PR TITLE
Add net worth graph

### DIFF
--- a/src/components/Match/matchPages.tsx
+++ b/src/components/Match/matchPages.tsx
@@ -287,6 +287,8 @@ const matchPages = (
             // sponsorIcon={gosuIcon}
           />
           <Spacer variant="2" />
+          <MatchGraph match={match} type="networth" />
+          <Spacer variant="2" />
           <MatchGraph match={match} type="gold" />
           <Spacer variant="2" />
           <MatchGraph match={match} type="xp" />

--- a/src/components/Visualizations/Graph/MatchGraph.tsx
+++ b/src/components/Visualizations/Graph/MatchGraph.tsx
@@ -369,6 +369,7 @@ const MatchGraph = ({
     type === "gold" ||
     type === "xp" ||
     type === "lh" ||
+    type === "networth" ||
     type === "hero_damage" ||
     type === "hero_healing" ||
     type === "camps_stacked"

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -107,6 +107,7 @@ type MatchPlayer = {
   desc: string;
   lane: number;
   gold_t: number[];
+  networth_t: number[];
   hero_damage_t: number[];
   hero_healing_t: number[];
   camps_stacked_t: number[];

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -344,6 +344,7 @@
   "heading_graph_gold": "Gold",
   "heading_graph_xp": "Experience",
   "heading_graph_lh": "Last Hits",
+  "heading_graph_networth": "Net Worth",
   "heading_graph_hero_damage": "Hero Damage",
   "heading_graph_hero_healing": "Hero Healing",
   "heading_graph_camps_stacked": "Camps Stacked",


### PR DESCRIPTION
Adds a Net Worth graph to the Graphs tab, using the `networth_t` series from odota/parser#92. It goes first among the per-player graphs since it's the curve broadcasts show.

![net worth graph](https://raw.githubusercontent.com/geracosta/web/assets/networth-graph-demo.png)

Net worth isn't the same curve as the existing Gold graph, which is total earned gold: it starts at 600 from the starting gold, and dips on buybacks where earned gold only ever climbs.

The graph component already handles any `<type>_t` field and renders nothing when it's absent, so matches parsed before the parser change are unaffected.

Draft until the parser side lands.