### PR TITLE
Rewrite the combos query so it stops timing out

### DIFF
--- a/src/components/Combos/getQueryString.ts
+++ b/src/components/Combos/getQueryString.ts
@@ -1,125 +1,42 @@
 const getQueryString = (teamA: number[], teamB: number[]) => {
-  const selectTeamA = [4, 3, 2, 1, 0]
-    .map(
-      (i) => `
-      pma${i}.hero_id
-    `,
-    )
-    .join();
+  const heroes = [...teamA, ...teamB];
 
-  const joinTeamA = [0, 1, 2, 3, 4]
-    .map(
-      (i) => `
-      JOIN player_matches pmA${i} 
-      ON pmA${i}.match_id = matches.match_id 
-      
-      ${teamA[i] ? `AND pmA${i}.hero_id = ${teamA[i]}` : (teamA.length > 0 && `AND pmA${i}.hero_id NOT IN (${teamA})`) || ""}
-  
-      ${!teamA[i] && i > 0 && !teamA[i - 1] ? `AND pmA${i}.hero_id > pmA${i - 1}.hero_id` : ""}
-    `,
-    )
-    .join(" ");
+  // "every one of these heroes is on this side"
+  const onSide = (team: number[], radiant: boolean) =>
+    team.length
+      ? `count(*) FILTER (WHERE hero_id IN (${team}) AND player_slot ${radiant ? "<" : ">="} 128) = ${team.length}`
+      : "true";
 
-  const joinTeamAConditions = [1, 2, 3, 4]
-    .map(
-      (i) => `
-      AND ( ( pmA0.player_slot < 5 ) = ( pmA${i}.player_Slot < 5 ) )
-    `,
-    )
-    .join(" ");
+  // The results table expects the picked heroes in fixed positions: team A ends
+  // with them in reverse pick order, team B starts with them in pick order
+  const layout = (team: number[], pickedFirst: boolean) =>
+    team.length
+      ? ` ORDER BY array_position(ARRAY[${team}], pm.hero_id) ${pickedFirst ? "ASC NULLS LAST" : "DESC NULLS FIRST"}`
+      : "";
 
-  const selectTeamB = [0, 1, 2, 3, 4]
-    .map(
-      (i) => `
-      pmB${i}.hero_id
-    `,
-    )
-    .join();
-
-  const joinTeamB = [0, 1, 2, 3, 4]
-    .map(
-      (i) => `
-      JOIN player_matches pmB${i} 
-      ON pmB${i}.match_id = matches.match_id 
-
-      ${teamB[i] ? `AND pmB${i}.hero_id = ${teamB[i]}` : (teamB.length > 0 && `AND pmB${i}.hero_id NOT IN (${teamB})`) || ""}
-  
-      ${!teamB[i] && i > 0 && !teamB[i - 1] ? `AND pmB${i}.hero_id > pmB${i - 1}.hero_id` : ""}            
-    `,
-    )
-    .join(" ");
-
-  const joinTeamBConditions = [0, 1, 2, 3, 4]
-    .map(
-      (i) => `
-      AND ( ( pmA0.player_slot < 5 ) = ( pmB${i}.player_Slot > 5 ) ) 
-    `,
-    )
-    .join(" ");
-
-  return `SELECT matches.match_id, matches.start_time,
-    ((pmA0.player_slot < 5) = matches.radiant_win) team_a_win,      
-    ARRAY[${selectTeamA}] team_a_composition, ARRAY[${selectTeamB}] team_b_composition
-    FROM matches            
-    ${joinTeamA} ${joinTeamAConditions} ${joinTeamB} ${joinTeamBConditions}
-    ORDER BY matches.start_time DESC LIMIT 500`;
+  // Find the matches with one pass over the picked heroes, then read the rest
+  // of the data for the few that survive. Joining player_matches once per slot
+  // instead makes postgres build enormous intermediate results and time out.
+  return `WITH candidates AS (
+    SELECT match_id,
+           ${teamA.length ? onSide(teamA, true) : `NOT (${onSide(teamB, true)})`} AS a_on_radiant
+    FROM player_matches
+    WHERE hero_id IN (${heroes})
+    GROUP BY match_id
+    HAVING (${onSide(teamA, true)} AND ${onSide(teamB, false)})
+        OR (${onSide(teamA, false)} AND ${onSide(teamB, true)})
+  )
+  SELECT m.match_id, m.start_time,
+         (c.a_on_radiant = m.radiant_win) team_a_win,
+         array_agg(pm.hero_id${layout(teamA, false)})
+           FILTER (WHERE (pm.player_slot < 128) = c.a_on_radiant) team_a_composition,
+         array_agg(pm.hero_id${layout(teamB, true)})
+           FILTER (WHERE (pm.player_slot < 128) <> c.a_on_radiant) team_b_composition
+  FROM candidates c
+  JOIN matches m USING (match_id)
+  JOIN player_matches pm USING (match_id)
+  GROUP BY m.match_id, m.start_time, c.a_on_radiant
+  ORDER BY m.start_time DESC LIMIT 500`;
 };
 
 export default getQueryString;
-
-/* EXAMPLE QUERY */
-/*
-/*
-/*
-SELECT
-matches.match_id,
-matches.start_time,
-array[pma4.hero_id, pma3.hero_id, pma2.hero_id, pma1.hero_id, pma0.hero_id]
-team_composition_a,
-array[pmb0.hero_id, pmb1.hero_id, pmb2.hero_id, pmb3.hero_id, pmb4.hero_id]
-team_composition_b
-FROM   matches
-       join player_matches pmA0
-         ON pmA0.match_id = matches.match_id
-            AND pmA0.hero_id = 5
-       join player_matches pmA1
-         ON pmA1.match_id = matches.match_id
-            AND pmA1.hero_id = 4
-       join player_matches pmA2
-         ON pmA2.match_id = matches.match_id
-            AND pmA2.hero_id NOT IN ( 5, 4 )
-       join player_matches pmA3
-         ON pmA3.match_id = matches.match_id
-            AND pmA3.hero_id NOT IN ( 5, 4 )
-            AND pmA3.hero_id > pmA2.hero_id
-       join player_matches pmA4
-         ON pmA4.match_id = matches.match_id
-            AND pmA4.hero_id NOT IN ( 5, 4 )
-            AND pmA4.hero_id > pmA3.hero_id
-            AND ( ( pmA0.player_slot < 5 ) = ( pmA1.player_slot < 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmA2.player_slot < 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmA3.player_slot < 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmA4.player_slot < 5 ) )
-       join player_matches pmB0
-         ON pmB0.match_id = matches.match_id
-            AND pmB0.hero_id = 6
-       join player_matches pmB1
-         ON pmB1.match_id = matches.match_id
-            AND pmB1.hero_id = 7
-       join player_matches pmB2
-         ON pmB2.match_id = matches.match_id
-            AND pmB2.hero_id NOT IN ( 6, 7 )
-       join player_matches pmB3
-         ON pmB3.match_id = matches.match_id
-            AND pmB3.hero_id NOT IN ( 6, 7 )
-            AND pmB3.hero_id > pmB2.hero_id
-       join player_matches pmB4
-         ON pmB4.match_id = matches.match_id
-            AND pmB4.hero_id NOT IN ( 6, 7 )
-            AND pmB4.hero_id > pmB3.hero_id
-            AND ( ( pmA0.player_slot < 5 ) = ( pmB0.player_slot > 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmB1.player_slot > 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmB2.player_slot > 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmB3.player_slot > 5 ) )
-            AND ( ( pmA0.player_slot < 5 ) = ( pmB4.player_slot > 5 ) )
-*/


### PR DESCRIPTION
The Combos page joins player_matches once per player slot, ten times, even when you only pick two heroes. Against the explorer's 15s statement timeout that query doesn't come back: I ran the page's own query for a 1v1 and a 2v2 and both timed out.

The plan explains it. 18 nested loops, and the inner node is estimated at 1.1 billion rows. The top line cost looks small (434) only because the planner assumes LIMIT 500 will be satisfied early, so when the combination isn't common it grinds until the timeout instead.

This does the lookup in one pass: filter player_matches to the picked heroes, group by match_id, let HAVING enforce that each side has its own, then read the compositions back for the few matches that survive.

Measured against the current query within the same minute:

| | current | this |
|---|---|---|
| 1 hero vs 1 hero | timeout at 15s | 86 rows in 375ms |
| 2 vs 2 | timeout at 15s | 17 rows in 4.6s |

Output is unchanged: same columns, and the composition arrays keep the layout the results table depends on, team A ending with the picked heroes in reverse pick order and team B starting with them. Verified on a real result.

One caveat, this is faster but not immune. The read replica varies a lot right now (the same query ran in 6.3s at one point and timed out an hour later), so heavy selections can still hit the cap. odota/core#2982 helps from the other side by covering match_id in the hero_id index, which is where most of the remaining cost sits.